### PR TITLE
Change replaceAll to replace

### DIFF
--- a/packages/core/src/analyze-entry.ts
+++ b/packages/core/src/analyze-entry.ts
@@ -31,7 +31,7 @@ const parseImportStatement = (statement: string): ParsedImportStatement => {
       });
     }
 
-    const defaultImport = importContent.replaceAll(',', '').trim();
+    const defaultImport = importContent.replace(/,/g, '').trim();
     output.defaultImport = defaultImport.length
       ? defaultImport
       : output.defaultImport;


### PR DESCRIPTION
Thank you for your great plugin.

I faced this issue because my project is using node v14.x while `replaceAll` is only available since node v15.0.0
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility
![image](https://user-images.githubusercontent.com/15927583/197716103-4335d995-9278-4fde-a969-5fbc1545c90f.png)


So I think it would be great if your plugin could support node v14 or have warning about minimum Node version 