### PR TITLE
Add "type": "module" to publishConfig

### DIFF
--- a/.changeset/rude-rivers-roll.md
+++ b/.changeset/rude-rivers-roll.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-entry-shaking': patch
+---
+
+Add `"type": "module"` to package.json

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "node": "^14.18.0 || >=16.0.0"
   },
   "publishConfig": {
+    "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts"


### PR DESCRIPTION
Fixes #20

Feel free to close

> **Note**
> I need you to review this and make sure `"type": "module"` works in "publishConfig" as expected.