### PR TITLE
fix: identifier with as in template strings has been removed

### DIFF
--- a/.changeset/odd-starfishes-provide.md
+++ b/.changeset/odd-starfishes-provide.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-entry-shaking": patch
+---
+
+Fixed identifiers containing "as" being removed from template strings (thanks [TobySJ](https://github.com/Shunjun))

--- a/packages/core/src/cleanup-entry.ts
+++ b/packages/core/src/cleanup-entry.ts
@@ -69,7 +69,7 @@ export function removeResolvedExports(
     output.overwrite(start, end, replacement);
   });
 
-  return output.toString().replace(/(\w*\s*as\s*)([,}])/gm, '$2');
+  return output.toString().replace(/(\w*\s+as\s+)([,}])/gm, '$2');
 }
 
 export const methods = {

--- a/packages/core/tests/cleanup-entry.test.ts
+++ b/packages/core/tests/cleanup-entry.test.ts
@@ -181,4 +181,18 @@ describe('removeResolvedExports', () => {
 
     expect(output).toStrictEqual(input);
   });
+
+  it('should not remove identifier with as in template strings', async () => {
+    const input = dedent(`
+      const someIdentifierWithas = 'SomeDefinedCode';
+      const code = \`\${someIdentifierWithas}\`;
+      `);
+    const exports = await getMockedExports(input);
+    const entryExports: EntryExports = new Map([
+      ['SomeDefinedCode', { path: '/some/path', importDefault: false }],
+    ]);
+
+    const output = EntryCleaner.removeResolvedExports(input, entryExports, exports);
+    expect(output).toStrictEqual(input);
+  });
 });


### PR DESCRIPTION
The identifier in template string has been removed

```ts
const code = `${someIdentifierWithas}` // => const code = `${}`
```