### PR TITLE
Fix entry file HMR

### DIFF
--- a/.changeset/fix-entry-file-hmr.md
+++ b/.changeset/fix-entry-file-hmr.md
@@ -1,5 +1,5 @@
 ---
-'vite-plugin-entry-shaking': patch
+'vite-plugin-entry-shaking': minor
 ---
 
 Fixed HMR for registered entry files by watching analyzed entries, re-analyzing changed entries, and invalidating transformed importers that depended on stale entry analysis.

--- a/.changeset/fix-entry-file-hmr.md
+++ b/.changeset/fix-entry-file-hmr.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed HMR for registered entry files by watching analyzed entries, re-analyzing changed entries, and invalidating transformed importers that depended on stale entry analysis.
+
+Fixed dev-server import rewrites when another Vite plugin remaps imports in `resolveId`, including package-entry and concrete-file remaps. Entry analysis and import matching now use final resolved ids from Vite's plugin container, and default alias re-exports remain available through wildcard entry chains.

--- a/.changeset/fix-entry-file-hmr.md
+++ b/.changeset/fix-entry-file-hmr.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-entry-shaking': patch
+---
+
+Fixed HMR for registered entry files by watching analyzed entries, re-analyzing changed entries, and invalidating transformed importers that depended on stale entry analysis.

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,13 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+!packages/core/tests/__mocks__/remap/node_modules/
+!packages/core/tests/__mocks__/remap/node_modules/**
 dev-dist
 dist
 dist-ssr
+!packages/core/tests/__mocks__/remap/**/dist/
+!packages/core/tests/__mocks__/remap/**/dist/**
 *.local
 
 # Tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,10 +8,7 @@
   },
   // ESLint.
   "eslint.validate": ["javascript", "javascriptreact", "yaml", "json", "jsonc", "json5"],
-  "eslint.workingDirectories": [
-    "./packages/core",
-    "./packages/debugger",
-  ],
+  "eslint.workingDirectories": ["./packages/core", "./packages/debugger"],
   "html.format.wrapAttributes": "force-expand-multiline",
   // Stylelint.
   "css.validate": false,

--- a/examples/_template_/eslint.config.js
+++ b/examples/_template_/eslint.config.js
@@ -1,5 +1,3 @@
 import vuePreset from '@yungezeit/eslint-vue';
 
-export default [
-  ...vuePreset,
-];
+export default [...vuePreset];

--- a/examples/glob-patterns/eslint.config.js
+++ b/examples/glob-patterns/eslint.config.js
@@ -1,5 +1,3 @@
 import vuePreset from '@yungezeit/eslint-vue';
 
-export default [
-  ...vuePreset,
-];
+export default [...vuePreset];

--- a/examples/issue-28/eslint.config.js
+++ b/examples/issue-28/eslint.config.js
@@ -1,5 +1,3 @@
 import vuePreset from '@yungezeit/eslint-vue';
 
-export default [
-  ...vuePreset,
-];
+export default [...vuePreset];

--- a/examples/issue-53/eslint.config.js
+++ b/examples/issue-53/eslint.config.js
@@ -1,5 +1,3 @@
 import vuePreset from '@yungezeit/eslint-vue';
 
-export default [
-  ...vuePreset,
-];
+export default [...vuePreset];

--- a/examples/issue-64/eslint.config.js
+++ b/examples/issue-64/eslint.config.js
@@ -1,5 +1,3 @@
 import vuePreset from '@yungezeit/eslint-vue';
 
-export default [
-  ...vuePreset,
-];
+export default [...vuePreset];

--- a/examples/issue-64/vite.config.ts
+++ b/examples/issue-64/vite.config.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import vue from '@vitejs/plugin-vue';
 import EntryShakingPlugin from 'vite-plugin-entry-shaking';
-import vueDevTools from 'vite-plugin-vue-devtools'
+import vueDevTools from 'vite-plugin-vue-devtools';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,7 +14,6 @@ export default defineConfig(() => ({
     EntryShakingPlugin({
       targets: [pathToLib],
       debug: true,
-
     }),
     vueDevTools(),
     vue(),

--- a/examples/jsx/eslint.config.js
+++ b/examples/jsx/eslint.config.js
@@ -1,5 +1,3 @@
 import vuePreset from '@yungezeit/eslint-vue';
 
-export default [
-  ...vuePreset,
-];
+export default [...vuePreset];

--- a/examples/syntaxes/eslint.config.js
+++ b/examples/syntaxes/eslint.config.js
@@ -1,5 +1,3 @@
 import vuePreset from '@yungezeit/eslint-vue';
 
-export default [
-  ...vuePreset,
-];
+export default [...vuePreset];

--- a/examples/vue-sfc/eslint.config.js
+++ b/examples/vue-sfc/eslint.config.js
@@ -1,5 +1,3 @@
 import vuePreset from '@yungezeit/eslint-vue';
 
-export default [
-  ...vuePreset,
-];
+export default [...vuePreset];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/Dschungelabenteuer/vite-plugin-entry-shaking/issues"
   },
-  "keywords": [
-    "vite",
-    "vite-plugin",
-    "entry",
-    "tree shaking"
-  ],
+  "keywords": ["vite", "vite-plugin", "entry", "tree shaking"],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -29,9 +24,7 @@
   },
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "engines": {
     "node": "^14.18.0 || >=16.0.0"
   },

--- a/packages/core/src/analyze-entry.ts
+++ b/packages/core/src/analyze-entry.ts
@@ -50,12 +50,15 @@ async function analyzeEntries(ctx: Context): Promise<PluginEntries> {
 async function analyzeEntry(ctx: Context, entryPath: EntryPath, depth: number): Promise<Duration> {
   if (ctx.entries.has(entryPath)) return [0, 0];
 
-  return await methods.doAnalyzeEntry(ctx, entryPath, depth).catch((e: unknown) => {
+  const duration = await methods.doAnalyzeEntry(ctx, entryPath, depth).catch((e: unknown) => {
     const message = `Could not analyze entry file "${entryPath}"`;
     console.error(e);
     ctx.logger.error(message);
     throw new Error(message);
   });
+
+  ctx.hmr.watchEntryFile(entryPath);
+  return duration;
 }
 
 /**

--- a/packages/core/src/analyze-entry.ts
+++ b/packages/core/src/analyze-entry.ts
@@ -28,8 +28,7 @@ async function analyzeEntries(ctx: Context): Promise<PluginEntries> {
   const { time, out } = await ctx.timer.measure('Analysis of target entry files', async () => {
     const targets = [...ctx.targets.entries()];
     await Utils.parallelize(targets, async ([path, depth]) => {
-      const absolutePath = (await ctx.resolver(path)) ?? path;
-      await methods.analyzeEntry(ctx, absolutePath, depth);
+      await methods.analyzeEntry(ctx, path, depth);
     });
     return ctx.entries;
   });
@@ -323,7 +322,9 @@ async function registerWildcardImportIfNeeded(
   depth: number,
 ): Promise<Duration> {
   return await ctx.timer.time(`Wilcard import analysis`, async (nonselfTime) => {
-    const importsEntry = ctx.targets.get(path) === 0;
+    const normalizedPath = ctx.normalizeId(path);
+    const resolvedPath = (await ctx.resolve(path, importedFrom)) ?? normalizedPath;
+    const importsEntry = ctx.targets.get(resolvedPath) === 0 || ctx.targets.get(normalizedPath) === 0;
     const maxDepthReached = depth >= ctx.options.maxWildcardDepth;
 
     if (maxDepthReached) {
@@ -368,7 +369,7 @@ async function registerWildcardImport(
   depth: number,
 ): Promise<Duration> {
   return await ctx.timer.time('Register wildcard import', async (nonselfTime) => {
-    const resolvedPath = await ctx.resolver(path, importedFrom);
+    const resolvedPath = await ctx.resolve(path, importedFrom);
     if (!resolvedPath || ctx.targets.has(resolvedPath)) return nonselfTime;
     ctx.logger.info(`Adding implicit target "${path}" because of a wildcard at "${importedFrom}"`);
     ctx.targets.set(resolvedPath, depth);

--- a/packages/core/src/analyze-entry.ts
+++ b/packages/core/src/analyze-entry.ts
@@ -322,8 +322,8 @@ async function registerWildcardImportIfNeeded(
   depth: number,
 ): Promise<Duration> {
   return await ctx.timer.time(`Wilcard import analysis`, async (nonselfTime) => {
-    const normalizedPath = ctx.normalizeId(path);
-    const resolvedPath = (await ctx.resolve(path, importedFrom)) ?? normalizedPath;
+    const normalizedPath = ctx.resolver.normalizeId(path);
+    const resolvedPath = (await ctx.resolver.resolve(path, importedFrom)) ?? normalizedPath;
     const importsEntry = ctx.targets.get(resolvedPath) === 0 || ctx.targets.get(normalizedPath) === 0;
     const maxDepthReached = depth >= ctx.options.maxWildcardDepth;
 
@@ -369,7 +369,7 @@ async function registerWildcardImport(
   depth: number,
 ): Promise<Duration> {
   return await ctx.timer.time('Register wildcard import', async (nonselfTime) => {
-    const resolvedPath = await ctx.resolve(path, importedFrom);
+    const resolvedPath = await ctx.resolver.resolve(path, importedFrom);
     if (!resolvedPath || ctx.targets.has(resolvedPath)) return nonselfTime;
     ctx.logger.info(`Adding implicit target "${path}" because of a wildcard at "${importedFrom}"`);
     ctx.targets.set(resolvedPath, depth);

--- a/packages/core/src/analyze-import.ts
+++ b/packages/core/src/analyze-import.ts
@@ -313,6 +313,22 @@ async function resolveImportedCircularEntities(
       });
 
       entityMap.set(resolvedPath, [...(entityMap.get(resolvedPath) ?? []), resolvedImports]);
+      continue;
+    }
+
+    const currentEntryExport = originalEntry.exports.get(name);
+    if (currentEntryExport) {
+      const resolvedPath = currentEntryExport.selfDefined
+        ? path
+        : await ctx.resolve(currentEntryExport.path, path);
+      if (!resolvedPath) continue;
+
+      const resolvedImports = methods.formatImportReplacement({
+        ...currentEntryExport,
+        name,
+        alias,
+      });
+      entityMap.set(resolvedPath, [...(entityMap.get(resolvedPath) ?? []), resolvedImports]);
     }
   }
 

--- a/packages/core/src/analyze-import.ts
+++ b/packages/core/src/analyze-import.ts
@@ -134,7 +134,7 @@ export async function findNamedImport(
 ) {
   const namedImport = entry.exports.get(name);
   if (namedImport) {
-    const resolvedPath = await ctx.resolver(namedImport.path, entryPath);
+    const resolvedPath = await ctx.resolve(namedImport.path, entryPath);
     if (resolvedPath) {
       const { importDefault, originalName } = namedImport;
       map.set(resolvedPath, [
@@ -165,7 +165,7 @@ export async function findNamedWildcard(
 ) {
   const wildcardImport = entry.wildcardExports?.named.get(name);
   if (wildcardImport) {
-    const resolvedPath = await ctx.resolver(wildcardImport, entryPath);
+    const resolvedPath = await ctx.resolve(wildcardImport, entryPath);
     const resolvedEntry = resolvedPath ? ctx.entries.get(resolvedPath) : undefined;
     if (resolvedPath && resolvedEntry) {
       map.set(resolvedPath, [
@@ -198,7 +198,7 @@ export async function findDirectWildcardExports(
 ) {
   const wildcardExports = entry.wildcardExports?.direct ?? [];
   for (const wildcardExportPath of wildcardExports) {
-    const resolvedPath = await ctx.resolver(wildcardExportPath, entryPath);
+    const resolvedPath = await ctx.resolve(wildcardExportPath, entryPath);
     const resolvedEntry = resolvedPath ? ctx.entries.get(resolvedPath) : undefined;
     const resolvedExport = resolvedEntry ? resolvedEntry.exports.get(name) : undefined;
     if (resolvedPath) {
@@ -303,7 +303,7 @@ async function resolveImportedCircularEntities(
 
     if (originalName && originalEntry.exports.has(originalName)) {
       const originalImport = originalEntry.exports.get(originalName)!;
-      const resolvedPath = await ctx.resolver(originalImport.path, path);
+      const resolvedPath = await ctx.resolve(originalImport.path, path);
       if (!resolvedPath) continue;
 
       const resolvedImports = methods.formatImportReplacement({

--- a/packages/core/src/analyze-import.ts
+++ b/packages/core/src/analyze-import.ts
@@ -134,7 +134,7 @@ export async function findNamedImport(
 ) {
   const namedImport = entry.exports.get(name);
   if (namedImport) {
-    const resolvedPath = await ctx.resolve(namedImport.path, entryPath);
+    const resolvedPath = await ctx.resolver.resolve(namedImport.path, entryPath);
     if (resolvedPath) {
       const { importDefault, originalName } = namedImport;
       map.set(resolvedPath, [
@@ -165,7 +165,7 @@ export async function findNamedWildcard(
 ) {
   const wildcardImport = entry.wildcardExports?.named.get(name);
   if (wildcardImport) {
-    const resolvedPath = await ctx.resolve(wildcardImport, entryPath);
+    const resolvedPath = await ctx.resolver.resolve(wildcardImport, entryPath);
     const resolvedEntry = resolvedPath ? ctx.entries.get(resolvedPath) : undefined;
     if (resolvedPath && resolvedEntry) {
       map.set(resolvedPath, [
@@ -198,7 +198,7 @@ export async function findDirectWildcardExports(
 ) {
   const wildcardExports = entry.wildcardExports?.direct ?? [];
   for (const wildcardExportPath of wildcardExports) {
-    const resolvedPath = await ctx.resolve(wildcardExportPath, entryPath);
+    const resolvedPath = await ctx.resolver.resolve(wildcardExportPath, entryPath);
     const resolvedEntry = resolvedPath ? ctx.entries.get(resolvedPath) : undefined;
     const resolvedExport = resolvedEntry ? resolvedEntry.exports.get(name) : undefined;
     if (resolvedPath) {
@@ -303,13 +303,13 @@ async function resolveImportedCircularEntities(
 
     if (originalName && originalEntry.exports.has(originalName)) {
       const originalImport = originalEntry.exports.get(originalName)!;
-      const resolvedPath = await ctx.resolve(originalImport.path, path);
+      const resolvedPath = await ctx.resolver.resolve(originalImport.path, path);
       if (!resolvedPath) continue;
 
       const resolvedImports = methods.formatImportReplacement({
         ...originalImport,
         name: originalName,
-        alias,
+        alias: alias ?? name,
       });
 
       entityMap.set(resolvedPath, [...(entityMap.get(resolvedPath) ?? []), resolvedImports]);
@@ -320,13 +320,13 @@ async function resolveImportedCircularEntities(
     if (currentEntryExport) {
       const resolvedPath = currentEntryExport.selfDefined
         ? path
-        : await ctx.resolve(currentEntryExport.path, path);
+        : await ctx.resolver.resolve(currentEntryExport.path, path);
       if (!resolvedPath) continue;
 
       const resolvedImports = methods.formatImportReplacement({
         ...currentEntryExport,
         name,
-        alias,
+        alias: alias ?? name,
       });
       entityMap.set(resolvedPath, [...(entityMap.get(resolvedPath) ?? []), resolvedImports]);
     }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -31,6 +31,9 @@ export class Context {
   /** Map of analyzed entries. */
   public entries: PluginEntries = new Map();
 
+  /** Whether targets and entries have already been initialized. */
+  private initialized = false;
+
   /** Map of registered targets. */
   public targets: ExtendedTargets = new Map();
 
@@ -74,15 +77,18 @@ export class Context {
 
   /** Initializes the plugin context. */
   public async init() {
+    if (this.initialized) return;
+
     await this.resolver.registerTargets();
     this.entries = await EntryAnalyzer.analyzeEntries(this);
-    this.hmr.includeEntriesInWatcherOptions();
 
     if (this.options.debug) {
       const { EventBus } = await loadEventBus();
       this.eventBus = new EventBus();
       this.logger.getOntoEventBus(this.eventBus);
     }
+
+    this.initialized = true;
   }
 
   /**

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,7 +1,9 @@
-import type { ResolveFn, ResolvedConfig } from 'vite';
+import type { FSWatcher, ModuleGraph, ModuleNode, ResolveFn, ResolvedConfig } from 'vite';
+import { normalizePath } from 'vite';
 import type { EventBus } from './event-bus';
 import type {
   ExtendedTargets,
+  EntryPath,
   PluginEntries,
   PluginMetrics,
   FinalPluginOptions,
@@ -11,7 +13,7 @@ import type {
 import { Logger } from './logger';
 
 import EntryAnalyzer from './analyze-entry';
-import { parseId } from './urls';
+import { addSourceQuerySuffix, parseId } from './urls';
 import { transformIfNeeded } from './transform';
 import Utils, { loadEventBus } from './utils';
 import { extensions } from './options';
@@ -28,6 +30,9 @@ export class Context {
 
   /** Map of registered targets. */
   public targets: ExtendedTargets = new Map();
+
+  /** Map of transformed importers indexed by the entry files they imported. */
+  public entryImporters = new Map<EntryPath, Set<string>>();
 
   /** Plugin's logger. */
   public logger: Logger;
@@ -70,6 +75,7 @@ export class Context {
   public async init() {
     await this.registerTargets();
     this.entries = await EntryAnalyzer.analyzeEntries(this);
+    this.includeEntriesInWatcherOptions();
 
     if (this.options.debug) {
       const { EventBus } = await loadEventBus();
@@ -118,17 +124,154 @@ export class Context {
    * @param id Path to the file.
    */
   public async checkUpdate(id: string) {
-    const entryFile = this.entries.get(id);
+    const entryId = normalizePath(parseId(id).url);
+    const entryFile = this.entries.get(entryId);
 
     if (entryFile) {
-      this.logger.info(`HMR requires new analysis of ${id}`);
-      await EntryAnalyzer.doAnalyzeEntry(this, id, entryFile.depth);
+      this.logger.info(`HMR requires new analysis of ${entryId}`);
+      await EntryAnalyzer.doAnalyzeEntry(this, entryId, entryFile.depth);
+      return true;
     }
+
+    return false;
+  }
+
+  /**
+   * Returns Vite module ids that can be served for an entry file.
+   * @param id Path to the changed entry file.
+   */
+  public getHotUpdateModuleIds(id: string) {
+    const entryId = normalizePath(parseId(id).url);
+
+    if (!this.entries.has(entryId)) return [];
+
+    return [entryId, addSourceQuerySuffix(entryId)];
+  }
+
+  /**
+   * Collects the entry modules that should be invalidated after an HMR update.
+   * @param id Path to the changed entry file.
+   * @param modules Modules Vite already associated to the changed file.
+   * @param moduleGraph Vite's module graph.
+   */
+  public getHotUpdateModules(
+    id: string,
+    modules: ModuleNode[],
+    moduleGraph: Pick<ModuleGraph, 'getModuleById' | 'getModulesByFile'>,
+  ) {
+    const affectedModules = new Set<ModuleNode>();
+    const moduleIds = this.getHotUpdateModuleIds(id);
+    const entryId = moduleIds[0];
+    const servedModuleIds = new Set(moduleIds);
+
+    if (!entryId) return [];
+
+    const addModule = (module?: ModuleNode) => {
+      if (module && this.isServedEntryModule(module, entryId, servedModuleIds)) {
+        affectedModules.add(module);
+      }
+    };
+    const addImporterModule = (module?: ModuleNode) => {
+      if (module) affectedModules.add(module);
+    };
+
+    modules.forEach(addModule);
+    moduleGraph.getModulesByFile(entryId)?.forEach(addModule);
+    moduleIds.forEach((moduleId) => {
+      addModule(moduleGraph.getModuleById(moduleId));
+    });
+    this.getEntryImporterIds(entryId).forEach((moduleId) => {
+      addImporterModule(moduleGraph.getModuleById(moduleId));
+    });
+
+    return [...affectedModules];
+  }
+
+  /**
+   * Registers which entries were used to transform an importer.
+   * @param importerId Resolved id of the transformed file.
+   * @param entryIds Resolved ids of the imported entries.
+   */
+  public registerEntryImporter(importerId: string, entryIds: EntryPath[]) {
+    const normalizedImporterId = normalizePath(importerId);
+    this.unregisterEntryImporter(normalizedImporterId);
+
+    entryIds.forEach((entryId) => {
+      const normalizedEntryId = normalizePath(parseId(entryId).url);
+      if (!this.entries.has(normalizedEntryId)) return;
+
+      const importers = this.entryImporters.get(normalizedEntryId) ?? new Set<string>();
+      importers.add(normalizedImporterId);
+      this.entryImporters.set(normalizedEntryId, importers);
+    });
+  }
+
+  /**
+   * Removes stale transformed-importer references.
+   * @param importerId Resolved id of a transformed file.
+   */
+  public unregisterEntryImporter(importerId: string) {
+    const normalizedImporterId = normalizePath(importerId);
+
+    this.entryImporters.forEach((importers, entryId) => {
+      importers.delete(normalizedImporterId);
+      if (!importers.size) this.entryImporters.delete(entryId);
+    });
+  }
+
+  /** Ensures Vite's dev watcher does not ignore registered entry files. */
+  public includeEntriesInWatcherOptions() {
+    const serverConfig = (this.config as { server?: ResolvedConfig['server'] }).server;
+    const watchOptions = serverConfig?.watch;
+    if (!watchOptions) return;
+
+    const ignored = watchOptions.ignored;
+    const ignoredList = Array.isArray(ignored) ? ignored : ignored ? [ignored] : [];
+    watchOptions.ignored = [...this.getEntryWatchIgnoreExceptions(), ...ignoredList];
+  }
+
+  /**
+   * Adds registered entry files to Vite's dev watcher.
+   * @param watcher Vite's dev server watcher.
+   */
+  public watchEntryFiles(watcher: Pick<FSWatcher, 'add'>) {
+    const entryIds = [...this.entries.keys()];
+    if (!entryIds.length) return;
+
+    this.logger.info(`Watching ${entryIds.length} entry file(s) for HMR`);
+    watcher.add(entryIds);
   }
 
   /** Registers targets from the plugin options. */
   private async registerTargets() {
     const paths = await Utils.getAllTargetPaths(this.options.targets);
     this.targets = new Map(paths.map((path) => [path, 0]));
+  }
+
+  /** Determines whether a Vite module is one of the entry modules served by this plugin. */
+  private isServedEntryModule(
+    module: ModuleNode,
+    entryId: string,
+    servedModuleIds: Set<string>,
+  ) {
+    if (!module.id) {
+      return module.file ? normalizePath(module.file) === entryId : false;
+    }
+
+    const moduleId = normalizePath(module.id);
+    if (servedModuleIds.has(moduleId)) return true;
+
+    const parsed = parseId(moduleId);
+    return parsed.url === entryId && parsed.serveSource;
+  }
+
+  /** Returns negative ignored patterns for entry files watched explicitly by this plugin. */
+  private getEntryWatchIgnoreExceptions() {
+    return [...this.entries.keys()].map((entryId) => `!${entryId}`);
+  }
+
+  /** Returns transformed importer ids that depended on the given entry analysis. */
+  private getEntryImporterIds(entryId: EntryPath) {
+    return [...(this.entryImporters.get(entryId) ?? [])];
   }
 }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -25,6 +25,9 @@ export class Context {
   /** Vite resolver. */
   public resolver: ResolveFn;
 
+  /** Whether targets and entries have already been initialized. */
+  private initialized = false;
+
   /** Map of analyzed entries. */
   public entries: PluginEntries = new Map();
 
@@ -73,6 +76,12 @@ export class Context {
 
   /**  Initializes the plugin context. */
   public async init() {
+    if (this.initialized) return;
+
+    this.targets = new Map();
+    this.entries = new Map();
+    this.entryImporters.clear();
+
     await this.registerTargets();
     this.entries = await EntryAnalyzer.analyzeEntries(this);
     this.includeEntriesInWatcherOptions();
@@ -82,6 +91,41 @@ export class Context {
       this.eventBus = new EventBus();
       this.logger.getOntoEventBus(this.eventBus);
     }
+
+    this.initialized = true;
+  }
+
+  /**
+   * Replaces the resolver used by the plugin.
+   * This invalidates any analysis previously built with another resolver.
+   * @param resolver Final Vite/Rollup resolver.
+   */
+  public setResolver(resolver: ResolveFn) {
+    this.resolver = resolver;
+    this.initialized = false;
+    this.targets = new Map();
+    this.entries = new Map();
+    this.entryImporters.clear();
+  }
+
+  /**
+   * Resolves and normalizes a module id through the active Vite resolver.
+   * @param id Imported id/specifier.
+   * @param importer Importer id.
+   * @param aliasOnly Whether only aliases should be resolved.
+   * @param ssr Whether the resolution is for SSR.
+   */
+  public async resolve(id: string, importer?: string, aliasOnly?: boolean, ssr?: boolean) {
+    const resolved = await this.resolver(id, importer, aliasOnly, ssr);
+    return resolved ? this.normalizeId(resolved) : undefined;
+  }
+
+  /**
+   * Normalizes a module id before using it as a target/entry cache key.
+   * @param id Module id.
+   */
+  public normalizeId(id: string) {
+    return normalizePath(parseId(id).url);
   }
 
   /**
@@ -90,12 +134,13 @@ export class Context {
    */
   public loadFile(id: string) {
     const { url, serveSource } = parseId(id);
-    const entry = this.entries.get(url);
+    const entryId = this.normalizeId(url);
+    const entry = this.entries.get(entryId);
 
     if (entry) {
       const version = serveSource ? 'original' : 'mutated';
       const output = serveSource ? entry.source : entry.updatedSource;
-      this.logger.info(`Serving ${version} version entry file ${url}`);
+      this.logger.info(`Serving ${version} version entry file ${entryId}`);
       return output;
     }
   }
@@ -245,7 +290,15 @@ export class Context {
   /** Registers targets from the plugin options. */
   private async registerTargets() {
     const paths = await Utils.getAllTargetPaths(this.options.targets);
-    this.targets = new Map(paths.map((path) => [path, 0]));
+    const targets: ExtendedTargets = new Map();
+
+    await Utils.parallelize(paths, async (path) => {
+      const resolvedPath = (await this.resolve(path)) ?? this.normalizeId(path);
+      this.logger.debug(`Registered target "${path}" as "${resolvedPath}"`);
+      targets.set(resolvedPath, 0);
+    });
+
+    this.targets = targets;
   }
 
   /** Determines whether a Vite module is one of the entry modules served by this plugin. */

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -249,11 +249,7 @@ export class Context {
   }
 
   /** Determines whether a Vite module is one of the entry modules served by this plugin. */
-  private isServedEntryModule(
-    module: ModuleNode,
-    entryId: string,
-    servedModuleIds: Set<string>,
-  ) {
+  private isServedEntryModule(module: ModuleNode, entryId: string, servedModuleIds: Set<string>) {
     if (!module.id) {
       return module.file ? normalizePath(module.file) === entryId : false;
     }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -34,8 +34,14 @@ export class Context {
   /** Map of registered targets. */
   public targets: ExtendedTargets = new Map();
 
+  /** Set of target ids exactly as configured before importer-specific resolution. */
+  public targetSpecifiers = new Set<EntryPath>();
+
   /** Map of transformed importers indexed by the entry files they imported. */
   public entryImporters = new Map<EntryPath, Set<string>>();
+
+  /** Vite's dev server watcher. */
+  private watcher?: Pick<FSWatcher, 'add'>;
 
   /** Plugin's logger. */
   public logger: Logger;
@@ -79,6 +85,7 @@ export class Context {
     if (this.initialized) return;
 
     this.targets = new Map();
+    this.targetSpecifiers.clear();
     this.entries = new Map();
     this.entryImporters.clear();
 
@@ -104,6 +111,7 @@ export class Context {
     this.resolver = resolver;
     this.initialized = false;
     this.targets = new Map();
+    this.targetSpecifiers.clear();
     this.entries = new Map();
     this.entryImporters.clear();
   }
@@ -126,6 +134,50 @@ export class Context {
    */
   public normalizeId(id: string) {
     return normalizePath(parseId(id).url);
+  }
+
+  /**
+   * Resolves an import with its real importer and ensures configured targets are
+   * analyzed under the final resolved identity.
+   * @param importPath Import specifier from the importer source.
+   * @param importer Importer id.
+   */
+  public async resolveEntryImport(importPath: string, importer: string) {
+    const resolvedPath = await this.resolve(importPath, importer);
+    if (!resolvedPath) return;
+
+    if (this.entries.has(resolvedPath)) return resolvedPath;
+    if (!(await this.isResolvedTargetImport(importPath, importer, resolvedPath))) return;
+
+    this.logger.info(`Adding importer-resolved target "${importPath}" as "${resolvedPath}"`);
+    this.targets.set(resolvedPath, 0);
+    await EntryAnalyzer.analyzeEntry(this, resolvedPath, 0);
+    this.watcher?.add(resolvedPath);
+
+    return this.entries.has(resolvedPath) ? resolvedPath : undefined;
+  }
+
+  private async isResolvedTargetImport(importPath: string, importer: string, resolvedPath: string) {
+    if (this.isTargetSpecifier(importPath)) return true;
+
+    for (const targetSpecifier of this.targetSpecifiers) {
+      const resolvedTarget = await this.resolve(targetSpecifier, importer);
+      if (resolvedTarget === resolvedPath) return true;
+    }
+
+    return false;
+  }
+
+  private isTargetSpecifier(importPath: string) {
+    const normalizedImport = this.normalizeId(importPath);
+
+    for (const targetSpecifier of this.targetSpecifiers) {
+      if (targetSpecifier === importPath || this.normalizeId(targetSpecifier) === normalizedImport) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**
@@ -280,6 +332,7 @@ export class Context {
    * @param watcher Vite's dev server watcher.
    */
   public watchEntryFiles(watcher: Pick<FSWatcher, 'add'>) {
+    this.watcher = watcher;
     const entryIds = [...this.entries.keys()];
     if (!entryIds.length) return;
 
@@ -293,6 +346,7 @@ export class Context {
     const targets: ExtendedTargets = new Map();
 
     await Utils.parallelize(paths, async (path) => {
+      this.targetSpecifiers.add(path);
       const resolvedPath = (await this.resolve(path)) ?? this.normalizeId(path);
       this.logger.debug(`Registered target "${path}" as "${resolvedPath}"`);
       targets.set(resolvedPath, 0);

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,47 +1,38 @@
-import type { FSWatcher, ModuleGraph, ModuleNode, ResolveFn, ResolvedConfig } from 'vite';
-import { normalizePath } from 'vite';
+import type { ResolvedConfig } from 'vite';
 import type { EventBus } from './event-bus';
 import type {
+  DebuggerEvents,
   ExtendedTargets,
-  EntryPath,
+  FinalPluginOptions,
   PluginEntries,
   PluginMetrics,
-  FinalPluginOptions,
-  DebuggerEvents,
 } from './types';
 
 import { Logger } from './logger';
 
 import EntryAnalyzer from './analyze-entry';
-import { addSourceQuerySuffix, parseId } from './urls';
+import { parseId } from './urls';
 import { transformIfNeeded } from './transform';
-import Utils, { loadEventBus } from './utils';
+import { loadEventBus } from './utils';
 import { extensions } from './options';
 import { Diagnostics } from './diagnostics';
+import { HMR } from './hmr';
+import { Resolver } from './resolver';
 import { Timer } from './timer';
 
 /** Plugin's context. */
 export class Context {
-  /** Vite resolver. */
-  public resolver: ResolveFn;
+  /** Plugin's resolver utilities. */
+  public resolver: Resolver;
 
-  /** Whether targets and entries have already been initialized. */
-  private initialized = false;
+  /** Plugin's HMR utilities. */
+  public hmr: HMR;
 
   /** Map of analyzed entries. */
   public entries: PluginEntries = new Map();
 
   /** Map of registered targets. */
   public targets: ExtendedTargets = new Map();
-
-  /** Set of target ids exactly as configured before importer-specific resolution. */
-  public targetSpecifiers = new Set<EntryPath>();
-
-  /** Map of transformed importers indexed by the entry files they imported. */
-  public entryImporters = new Map<EntryPath, Set<string>>();
-
-  /** Vite's dev server watcher. */
-  private watcher?: Pick<FSWatcher, 'add'>;
 
   /** Plugin's logger. */
   public logger: Logger;
@@ -73,111 +64,25 @@ export class Context {
     public options: Required<FinalPluginOptions>,
     public config: ResolvedConfig,
   ) {
-    this.resolver = config.createResolver();
     this.logger = new Logger(config.logger, false);
     this.logger.info('Plugin configuration resolved');
     this.diagnostics = new Diagnostics(this.options);
     this.timer = new Timer(this.logger);
+    this.resolver = new Resolver(this, config.createResolver());
+    this.hmr = new HMR(this);
   }
 
-  /**  Initializes the plugin context. */
+  /** Initializes the plugin context. */
   public async init() {
-    if (this.initialized) return;
-
-    this.targets = new Map();
-    this.targetSpecifiers.clear();
-    this.entries = new Map();
-    this.entryImporters.clear();
-
-    await this.registerTargets();
+    await this.resolver.registerTargets();
     this.entries = await EntryAnalyzer.analyzeEntries(this);
-    this.includeEntriesInWatcherOptions();
+    this.hmr.includeEntriesInWatcherOptions();
 
     if (this.options.debug) {
       const { EventBus } = await loadEventBus();
       this.eventBus = new EventBus();
       this.logger.getOntoEventBus(this.eventBus);
     }
-
-    this.initialized = true;
-  }
-
-  /**
-   * Replaces the resolver used by the plugin.
-   * This invalidates any analysis previously built with another resolver.
-   * @param resolver Final Vite/Rollup resolver.
-   */
-  public setResolver(resolver: ResolveFn) {
-    this.resolver = resolver;
-    this.initialized = false;
-    this.targets = new Map();
-    this.targetSpecifiers.clear();
-    this.entries = new Map();
-    this.entryImporters.clear();
-  }
-
-  /**
-   * Resolves and normalizes a module id through the active Vite resolver.
-   * @param id Imported id/specifier.
-   * @param importer Importer id.
-   * @param aliasOnly Whether only aliases should be resolved.
-   * @param ssr Whether the resolution is for SSR.
-   */
-  public async resolve(id: string, importer?: string, aliasOnly?: boolean, ssr?: boolean) {
-    const resolved = await this.resolver(id, importer, aliasOnly, ssr);
-    return resolved ? this.normalizeId(resolved) : undefined;
-  }
-
-  /**
-   * Normalizes a module id before using it as a target/entry cache key.
-   * @param id Module id.
-   */
-  public normalizeId(id: string) {
-    return normalizePath(parseId(id).url);
-  }
-
-  /**
-   * Resolves an import with its real importer and ensures configured targets are
-   * analyzed under the final resolved identity.
-   * @param importPath Import specifier from the importer source.
-   * @param importer Importer id.
-   */
-  public async resolveEntryImport(importPath: string, importer: string) {
-    const resolvedPath = await this.resolve(importPath, importer);
-    if (!resolvedPath) return;
-
-    if (this.entries.has(resolvedPath)) return resolvedPath;
-    if (!(await this.isResolvedTargetImport(importPath, importer, resolvedPath))) return;
-
-    this.logger.info(`Adding importer-resolved target "${importPath}" as "${resolvedPath}"`);
-    this.targets.set(resolvedPath, 0);
-    await EntryAnalyzer.analyzeEntry(this, resolvedPath, 0);
-    this.watcher?.add(resolvedPath);
-
-    return this.entries.has(resolvedPath) ? resolvedPath : undefined;
-  }
-
-  private async isResolvedTargetImport(importPath: string, importer: string, resolvedPath: string) {
-    if (this.isTargetSpecifier(importPath)) return true;
-
-    for (const targetSpecifier of this.targetSpecifiers) {
-      const resolvedTarget = await this.resolve(targetSpecifier, importer);
-      if (resolvedTarget === resolvedPath) return true;
-    }
-
-    return false;
-  }
-
-  private isTargetSpecifier(importPath: string) {
-    const normalizedImport = this.normalizeId(importPath);
-
-    for (const targetSpecifier of this.targetSpecifiers) {
-      if (targetSpecifier === importPath || this.normalizeId(targetSpecifier) === normalizedImport) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   /**
@@ -186,7 +91,7 @@ export class Context {
    */
   public loadFile(id: string) {
     const { url, serveSource } = parseId(id);
-    const entryId = this.normalizeId(url);
+    const entryId = this.resolver.normalizeId(url);
     const entry = this.entries.get(entryId);
 
     if (entry) {
@@ -213,168 +118,5 @@ export class Context {
     }
 
     return await transformIfNeeded(this, id, code);
-  }
-
-  /**
-   * Checks if hot update matches any of the entries.
-   * If it does, re-triggers the analysis of that entry.
-   * @param id Path to the file.
-   */
-  public async checkUpdate(id: string) {
-    const entryId = normalizePath(parseId(id).url);
-    const entryFile = this.entries.get(entryId);
-
-    if (entryFile) {
-      this.logger.info(`HMR requires new analysis of ${entryId}`);
-      await EntryAnalyzer.doAnalyzeEntry(this, entryId, entryFile.depth);
-      return true;
-    }
-
-    return false;
-  }
-
-  /**
-   * Returns Vite module ids that can be served for an entry file.
-   * @param id Path to the changed entry file.
-   */
-  public getHotUpdateModuleIds(id: string) {
-    const entryId = normalizePath(parseId(id).url);
-
-    if (!this.entries.has(entryId)) return [];
-
-    return [entryId, addSourceQuerySuffix(entryId)];
-  }
-
-  /**
-   * Collects the entry modules that should be invalidated after an HMR update.
-   * @param id Path to the changed entry file.
-   * @param modules Modules Vite already associated to the changed file.
-   * @param moduleGraph Vite's module graph.
-   */
-  public getHotUpdateModules(
-    id: string,
-    modules: ModuleNode[],
-    moduleGraph: Pick<ModuleGraph, 'getModuleById' | 'getModulesByFile'>,
-  ) {
-    const affectedModules = new Set<ModuleNode>();
-    const moduleIds = this.getHotUpdateModuleIds(id);
-    const entryId = moduleIds[0];
-    const servedModuleIds = new Set(moduleIds);
-
-    if (!entryId) return [];
-
-    const addModule = (module?: ModuleNode) => {
-      if (module && this.isServedEntryModule(module, entryId, servedModuleIds)) {
-        affectedModules.add(module);
-      }
-    };
-    const addImporterModule = (module?: ModuleNode) => {
-      if (module) affectedModules.add(module);
-    };
-
-    modules.forEach(addModule);
-    moduleGraph.getModulesByFile(entryId)?.forEach(addModule);
-    moduleIds.forEach((moduleId) => {
-      addModule(moduleGraph.getModuleById(moduleId));
-    });
-    this.getEntryImporterIds(entryId).forEach((moduleId) => {
-      addImporterModule(moduleGraph.getModuleById(moduleId));
-    });
-
-    return [...affectedModules];
-  }
-
-  /**
-   * Registers which entries were used to transform an importer.
-   * @param importerId Resolved id of the transformed file.
-   * @param entryIds Resolved ids of the imported entries.
-   */
-  public registerEntryImporter(importerId: string, entryIds: EntryPath[]) {
-    const normalizedImporterId = normalizePath(importerId);
-    this.unregisterEntryImporter(normalizedImporterId);
-
-    entryIds.forEach((entryId) => {
-      const normalizedEntryId = normalizePath(parseId(entryId).url);
-      if (!this.entries.has(normalizedEntryId)) return;
-
-      const importers = this.entryImporters.get(normalizedEntryId) ?? new Set<string>();
-      importers.add(normalizedImporterId);
-      this.entryImporters.set(normalizedEntryId, importers);
-    });
-  }
-
-  /**
-   * Removes stale transformed-importer references.
-   * @param importerId Resolved id of a transformed file.
-   */
-  public unregisterEntryImporter(importerId: string) {
-    const normalizedImporterId = normalizePath(importerId);
-
-    this.entryImporters.forEach((importers, entryId) => {
-      importers.delete(normalizedImporterId);
-      if (!importers.size) this.entryImporters.delete(entryId);
-    });
-  }
-
-  /** Ensures Vite's dev watcher does not ignore registered entry files. */
-  public includeEntriesInWatcherOptions() {
-    const serverConfig = (this.config as { server?: ResolvedConfig['server'] }).server;
-    const watchOptions = serverConfig?.watch;
-    if (!watchOptions) return;
-
-    const ignored = watchOptions.ignored;
-    const ignoredList = Array.isArray(ignored) ? ignored : ignored ? [ignored] : [];
-    watchOptions.ignored = [...this.getEntryWatchIgnoreExceptions(), ...ignoredList];
-  }
-
-  /**
-   * Adds registered entry files to Vite's dev watcher.
-   * @param watcher Vite's dev server watcher.
-   */
-  public watchEntryFiles(watcher: Pick<FSWatcher, 'add'>) {
-    this.watcher = watcher;
-    const entryIds = [...this.entries.keys()];
-    if (!entryIds.length) return;
-
-    this.logger.info(`Watching ${entryIds.length} entry file(s) for HMR`);
-    watcher.add(entryIds);
-  }
-
-  /** Registers targets from the plugin options. */
-  private async registerTargets() {
-    const paths = await Utils.getAllTargetPaths(this.options.targets);
-    const targets: ExtendedTargets = new Map();
-
-    await Utils.parallelize(paths, async (path) => {
-      this.targetSpecifiers.add(path);
-      const resolvedPath = (await this.resolve(path)) ?? this.normalizeId(path);
-      this.logger.debug(`Registered target "${path}" as "${resolvedPath}"`);
-      targets.set(resolvedPath, 0);
-    });
-
-    this.targets = targets;
-  }
-
-  /** Determines whether a Vite module is one of the entry modules served by this plugin. */
-  private isServedEntryModule(module: ModuleNode, entryId: string, servedModuleIds: Set<string>) {
-    if (!module.id) {
-      return module.file ? normalizePath(module.file) === entryId : false;
-    }
-
-    const moduleId = normalizePath(module.id);
-    if (servedModuleIds.has(moduleId)) return true;
-
-    const parsed = parseId(moduleId);
-    return parsed.url === entryId && parsed.serveSource;
-  }
-
-  /** Returns negative ignored patterns for entry files watched explicitly by this plugin. */
-  private getEntryWatchIgnoreExceptions() {
-    return [...this.entries.keys()].map((entryId) => `!${entryId}`);
-  }
-
-  /** Returns transformed importer ids that depended on the given entry analysis. */
-  private getEntryImporterIds(entryId: EntryPath) {
-    return [...(this.entryImporters.get(entryId) ?? [])];
   }
 }

--- a/packages/core/src/hmr.ts
+++ b/packages/core/src/hmr.ts
@@ -10,8 +10,11 @@ export class HMR {
   /** Map of transformed importers indexed by the entry files they imported. */
   public entryImporters = new Map<EntryPath, Set<string>>();
 
+  /** Entry files registered for explicit watching. */
+  private watchedEntries = new Set<EntryPath>();
+
   /** Vite's dev server watcher. */
-  private watcher?: Pick<FSWatcher, 'add'>;
+  private watcher?: Pick<FSWatcher, 'add' | 'options'>;
 
   constructor(private context: Context) {}
 
@@ -118,22 +121,28 @@ export class HMR {
 
   /** Ensures Vite's dev watcher does not ignore registered entry files. */
   public includeEntriesInWatcherOptions() {
-    const serverConfig = (this.context.config as { server?: ResolvedConfig['server'] }).server;
-    const watchOptions = serverConfig?.watch;
+    const watchOptions = this.getWatchOptions();
     if (!watchOptions) return;
 
     const ignored = watchOptions.ignored;
     const ignoredList = Array.isArray(ignored) ? ignored : ignored ? [ignored] : [];
-    watchOptions.ignored = [...this.getEntryWatchIgnoreExceptions(), ...ignoredList];
+    const exceptions = this.getEntryWatchIgnoreExceptions();
+    const exceptionSet = new Set(exceptions);
+    watchOptions.ignored = [
+      ...exceptions,
+      ...ignoredList.filter((pattern) => typeof pattern !== 'string' || !exceptionSet.has(pattern)),
+    ];
   }
 
   /**
    * Adds registered entry files to Vite's dev watcher.
    * @param watcher Vite's dev server watcher.
    */
-  public watchEntryFiles(watcher: Pick<FSWatcher, 'add'>) {
+  public watchEntryFiles(watcher: Pick<FSWatcher, 'add' | 'options'>) {
     this.watcher = watcher;
-    const entryIds = [...this.context.entries.keys()];
+    const entryIds = [...new Set([...this.context.entries.keys(), ...this.watchedEntries])].map(
+      (entryId) => this.registerEntryForWatching(entryId),
+    );
     if (!entryIds.length) return;
 
     this.context.logger.info(`Watching ${entryIds.length} entry file(s) for HMR`);
@@ -145,7 +154,8 @@ export class HMR {
    * @param entryId Resolved entry id.
    */
   public watchEntryFile(entryId: EntryPath) {
-    this.watcher?.add(entryId);
+    const normalizedEntryId = this.registerEntryForWatching(entryId);
+    this.watcher?.add(normalizedEntryId);
   }
 
   /** Determines whether a Vite module is one of the entry modules served by this plugin. */
@@ -163,7 +173,44 @@ export class HMR {
 
   /** Returns negative ignored patterns for entry files watched explicitly by this plugin. */
   private getEntryWatchIgnoreExceptions() {
-    return [...this.context.entries.keys()].map((entryId) => `!${entryId}`);
+    return [...new Set([...this.context.entries.keys(), ...this.watchedEntries])].map(
+      (entryId) => `!${entryId}`,
+    );
+  }
+
+  /** Registers an entry with the live watcher keep policy. */
+  private registerEntryForWatching(entryId: EntryPath) {
+    const normalizedEntryId = normalizePath(parseId(entryId).url);
+    this.watchedEntries.add(normalizedEntryId);
+    this.addEntryWatchIgnoreException(normalizedEntryId);
+    return normalizedEntryId;
+  }
+
+  /** Adds an entry exception to the configured and active watcher options. */
+  private addEntryWatchIgnoreException(entryId: EntryPath) {
+    const exception = `!${entryId}`;
+    const watchOptions = this.getWatchOptions();
+
+    if (watchOptions) {
+      const ignored = watchOptions.ignored;
+      const ignoredList = Array.isArray(ignored) ? ignored : ignored ? [ignored] : [];
+      if (!ignoredList.includes(exception)) {
+        watchOptions.ignored = [exception, ...ignoredList];
+      }
+    }
+
+    const activeIgnored = this.watcher?.options.ignored;
+    if (Array.isArray(activeIgnored) && !activeIgnored.includes(exception)) {
+      activeIgnored.unshift(exception);
+    }
+  }
+
+  /** Returns Vite's configured watcher options when file watching is enabled. */
+  private getWatchOptions() {
+    const serverConfig = (this.context.config as { server?: ResolvedConfig['server'] }).server;
+    if (!serverConfig || serverConfig.watch === null) return;
+
+    return (serverConfig.watch ??= {});
   }
 
   /** Returns transformed importer ids that depended on the given entry analysis. */

--- a/packages/core/src/hmr.ts
+++ b/packages/core/src/hmr.ts
@@ -1,0 +1,173 @@
+import type { FSWatcher, ModuleGraph, ModuleNode, ResolvedConfig } from 'vite';
+import { normalizePath } from 'vite';
+import EntryAnalyzer from './analyze-entry';
+import type { Context } from './context';
+import type { EntryPath } from './types';
+import { addSourceQuerySuffix, parseId } from './urls';
+
+/** Plugin's HMR utilities. */
+export class HMR {
+  /** Map of transformed importers indexed by the entry files they imported. */
+  public entryImporters = new Map<EntryPath, Set<string>>();
+
+  /** Vite's dev server watcher. */
+  private watcher?: Pick<FSWatcher, 'add'>;
+
+  constructor(private context: Context) {}
+
+  /**
+   * Checks if a hot update matches any of the entries.
+   * If it does, re-triggers the analysis of that entry.
+   * @param id Path to the file.
+   */
+  public async checkUpdate(id: string) {
+    const entryId = normalizePath(parseId(id).url);
+    const entryFile = this.context.entries.get(entryId);
+
+    if (entryFile) {
+      this.context.logger.info(`HMR requires new analysis of ${entryId}`);
+      await EntryAnalyzer.doAnalyzeEntry(this.context, entryId, entryFile.depth);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Returns Vite module ids that can be served for an entry file.
+   * @param id Path to the changed entry file.
+   */
+  public getHotUpdateModuleIds(id: string) {
+    const entryId = normalizePath(parseId(id).url);
+
+    if (!this.context.entries.has(entryId)) return [];
+
+    return [entryId, addSourceQuerySuffix(entryId)];
+  }
+
+  /**
+   * Collects the entry modules that should be invalidated after an HMR update.
+   * @param id Path to the changed entry file.
+   * @param modules Modules Vite already associated to the changed file.
+   * @param moduleGraph Vite's module graph.
+   */
+  public getHotUpdateModules(
+    id: string,
+    modules: ModuleNode[],
+    moduleGraph: Pick<ModuleGraph, 'getModuleById' | 'getModulesByFile'>,
+  ) {
+    const affectedModules = new Set<ModuleNode>();
+    const moduleIds = this.getHotUpdateModuleIds(id);
+    const entryId = moduleIds[0];
+    const servedModuleIds = new Set(moduleIds);
+
+    if (!entryId) return [];
+
+    const addModule = (module?: ModuleNode) => {
+      if (module && this.isServedEntryModule(module, entryId, servedModuleIds)) {
+        affectedModules.add(module);
+      }
+    };
+    const addImporterModule = (module?: ModuleNode) => {
+      if (module) affectedModules.add(module);
+    };
+
+    modules.forEach(addModule);
+    moduleGraph.getModulesByFile(entryId)?.forEach(addModule);
+    moduleIds.forEach((moduleId) => {
+      addModule(moduleGraph.getModuleById(moduleId));
+    });
+    this.getEntryImporterIds(entryId).forEach((moduleId) => {
+      addImporterModule(moduleGraph.getModuleById(moduleId));
+    });
+
+    return [...affectedModules];
+  }
+
+  /**
+   * Registers which entries were used to transform an importer.
+   * @param importerId Resolved id of a transformed file.
+   * @param entryIds Resolved ids of the imported entries.
+   */
+  public registerEntryImporter(importerId: string, entryIds: EntryPath[]) {
+    const normalizedImporterId = normalizePath(importerId);
+    this.unregisterEntryImporter(normalizedImporterId);
+
+    entryIds.forEach((entryId) => {
+      const normalizedEntryId = normalizePath(parseId(entryId).url);
+      if (!this.context.entries.has(normalizedEntryId)) return;
+
+      const importers = this.entryImporters.get(normalizedEntryId) ?? new Set<string>();
+      importers.add(normalizedImporterId);
+      this.entryImporters.set(normalizedEntryId, importers);
+    });
+  }
+
+  /**
+   * Removes stale transformed-importer references.
+   * @param importerId Resolved id of a transformed file.
+   */
+  public unregisterEntryImporter(importerId: string) {
+    const normalizedImporterId = normalizePath(importerId);
+
+    this.entryImporters.forEach((importers, entryId) => {
+      importers.delete(normalizedImporterId);
+      if (!importers.size) this.entryImporters.delete(entryId);
+    });
+  }
+
+  /** Ensures Vite's dev watcher does not ignore registered entry files. */
+  public includeEntriesInWatcherOptions() {
+    const serverConfig = (this.context.config as { server?: ResolvedConfig['server'] }).server;
+    const watchOptions = serverConfig?.watch;
+    if (!watchOptions) return;
+
+    const ignored = watchOptions.ignored;
+    const ignoredList = Array.isArray(ignored) ? ignored : ignored ? [ignored] : [];
+    watchOptions.ignored = [...this.getEntryWatchIgnoreExceptions(), ...ignoredList];
+  }
+
+  /**
+   * Adds registered entry files to Vite's dev watcher.
+   * @param watcher Vite's dev server watcher.
+   */
+  public watchEntryFiles(watcher: Pick<FSWatcher, 'add'>) {
+    this.watcher = watcher;
+    const entryIds = [...this.context.entries.keys()];
+    if (!entryIds.length) return;
+
+    this.context.logger.info(`Watching ${entryIds.length} entry file(s) for HMR`);
+    watcher.add(entryIds);
+  }
+
+  /**
+   * Adds an entry discovered after server configuration to Vite's watcher.
+   * @param entryId Resolved entry id.
+   */
+  public watchEntryFile(entryId: EntryPath) {
+    this.watcher?.add(entryId);
+  }
+
+  /** Determines whether a Vite module is one of the entry modules served by this plugin. */
+  private isServedEntryModule(module: ModuleNode, entryId: string, servedModuleIds: Set<string>) {
+    if (!module.id) {
+      return module.file ? normalizePath(module.file) === entryId : false;
+    }
+
+    const moduleId = normalizePath(module.id);
+    if (servedModuleIds.has(moduleId)) return true;
+
+    const parsed = parseId(moduleId);
+    return parsed.url === entryId && parsed.serveSource;
+  }
+
+  /** Returns negative ignored patterns for entry files watched explicitly by this plugin. */
+  private getEntryWatchIgnoreExceptions() {
+    return [...this.context.entries.keys()].map((entryId) => `!${entryId}`);
+  }
+
+  /** Returns transformed importer ids that depended on the given entry analysis. */
+  private getEntryImporterIds(entryId: EntryPath) {
+    return [...(this.entryImporters.get(entryId) ?? [])];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import type { ModuleNode, Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+import type { ModuleNode, Plugin, ResolvedConfig } from 'vite';
 import type {
   Diagnostic,
   PluginMetrics,
@@ -59,15 +59,16 @@ export function createEntryShakingPlugin(userOptions: PluginOptions): Plugin[] {
       apply: 'serve',
       enforce: 'post',
 
-      async configResolved(config) {
+      configResolved(config) {
         // @ts-expect-error Who hijacks last hijacks best
         config.createResolver = originalCreateResolver;
         context = new Context(options, config);
-        await context.init();
+        context.hmr.includeEntriesInWatcherOptions();
       },
 
       async configureServer(server) {
-        context.resolver.usePluginContainer(server as Partial<ViteDevServer>);
+        context.resolver.usePluginContainer(server);
+        await context.init();
         context.hmr.watchEntryFiles(server.watcher);
 
         if (context.options.debug) {
@@ -76,15 +77,18 @@ export function createEntryShakingPlugin(userOptions: PluginOptions): Plugin[] {
         }
       },
 
-      load(id) {
+      async load(id) {
+        await context.init();
         return context.loadFile(id);
       },
 
       async transform(code, id) {
+        await context.init();
         return await context.transformFile(code, id);
       },
 
       async handleHotUpdate({ file, modules, server, timestamp }) {
+        await context.init();
         const isEntryUpdate = await context.hmr.checkUpdate(file);
 
         if (!isEntryUpdate) return;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,29 +59,16 @@ export function createEntryShakingPlugin(userOptions: PluginOptions): Plugin[] {
       apply: 'serve',
       enforce: 'post',
 
-      configResolved(config) {
+      async configResolved(config) {
         // @ts-expect-error Who hijacks last hijacks best
         config.createResolver = originalCreateResolver;
         context = new Context(options, config);
+        await context.init();
       },
 
       async configureServer(server) {
-        const fallbackResolver = context.resolver;
-        const { pluginContainer } = server as Partial<ViteDevServer>;
-
-        if (pluginContainer) {
-          context.setResolver(async (id, importer, aliasOnly, ssr) => {
-            if (aliasOnly) return await fallbackResolver(id, importer, aliasOnly, ssr);
-
-            const resolved = await pluginContainer.resolveId(id, importer, { ssr });
-            if (resolved) return typeof resolved === 'string' ? resolved : resolved.id;
-
-            return await fallbackResolver(id, importer, aliasOnly, ssr);
-          });
-        }
-
-        await context.init();
-        context.watchEntryFiles(server.watcher);
+        context.resolver.usePluginContainer(server as Partial<ViteDevServer>);
+        context.hmr.watchEntryFiles(server.watcher);
 
         if (context.options.debug) {
           const { attachDebugger } = await loadDebugger();
@@ -89,30 +76,28 @@ export function createEntryShakingPlugin(userOptions: PluginOptions): Plugin[] {
         }
       },
 
-      async load(id) {
-        await context.init();
+      load(id) {
         return context.loadFile(id);
       },
 
       async transform(code, id) {
-        await context.init();
         return await context.transformFile(code, id);
       },
 
       async handleHotUpdate({ file, modules, server, timestamp }) {
-        await context.init();
-        const isEntryUpdate = await context.checkUpdate(file);
+        const isEntryUpdate = await context.hmr.checkUpdate(file);
 
         if (!isEntryUpdate) return;
 
-        const affectedModules = context.getHotUpdateModules(file, modules, server.moduleGraph);
+        const affectedModules = context.hmr.getHotUpdateModules(file, modules, server.moduleGraph);
         const invalidatedModules = new Set<ModuleNode>();
 
         for (const module of affectedModules) {
           server.moduleGraph.invalidateModule(module, invalidatedModules, timestamp, true);
         }
 
-        // Import rewrites can remove the graph edge from consumers back to the entry.
+        // Rewritten imports bypass the entry module, so Vite cannot propagate its update
+        // to every consumer through the module graph. Reload to execute the new imports.
         server.ws.send({ type: 'full-reload' });
         return [];
       },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin, ResolvedConfig } from 'vite';
+import type { ModuleNode, Plugin, ResolvedConfig } from 'vite';
 import type {
   Diagnostic,
   PluginMetrics,
@@ -67,6 +67,8 @@ export function createEntryShakingPlugin(userOptions: PluginOptions): Plugin[] {
       },
 
       async configureServer(server) {
+        context.watchEntryFiles(server.watcher);
+
         if (context.options.debug) {
           const { attachDebugger } = await loadDebugger();
           attachDebugger(server, context);
@@ -81,8 +83,21 @@ export function createEntryShakingPlugin(userOptions: PluginOptions): Plugin[] {
         return await context.transformFile(code, id);
       },
 
-      async handleHotUpdate({ file }) {
-        await context.checkUpdate(file);
+      async handleHotUpdate({ file, modules, server, timestamp }) {
+        const isEntryUpdate = await context.checkUpdate(file);
+
+        if (!isEntryUpdate) return;
+
+        const affectedModules = context.getHotUpdateModules(file, modules, server.moduleGraph);
+        const invalidatedModules = new Set<ModuleNode>();
+
+        for (const module of affectedModules) {
+          server.moduleGraph.invalidateModule(module, invalidatedModules, timestamp, true);
+        }
+
+        // Import rewrites can remove the graph edge from consumers back to the entry.
+        server.ws.send({ type: 'full-reload' });
+        return [];
       },
     },
   ];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import type { ModuleNode, Plugin, ResolvedConfig } from 'vite';
+import type { ModuleNode, Plugin, ResolvedConfig, ViteDevServer } from 'vite';
 import type {
   Diagnostic,
   PluginMetrics,
@@ -59,14 +59,28 @@ export function createEntryShakingPlugin(userOptions: PluginOptions): Plugin[] {
       apply: 'serve',
       enforce: 'post',
 
-      async configResolved(config) {
+      configResolved(config) {
         // @ts-expect-error Who hijacks last hijacks best
         config.createResolver = originalCreateResolver;
         context = new Context(options, config);
-        await context.init();
       },
 
       async configureServer(server) {
+        const fallbackResolver = context.resolver;
+        const { pluginContainer } = server as Partial<ViteDevServer>;
+
+        if (pluginContainer) {
+          context.setResolver(async (id, importer, aliasOnly, ssr) => {
+            if (aliasOnly) return await fallbackResolver(id, importer, aliasOnly, ssr);
+
+            const resolved = await pluginContainer.resolveId(id, importer, { ssr });
+            if (resolved) return typeof resolved === 'string' ? resolved : resolved.id;
+
+            return await fallbackResolver(id, importer, aliasOnly, ssr);
+          });
+        }
+
+        await context.init();
         context.watchEntryFiles(server.watcher);
 
         if (context.options.debug) {
@@ -75,15 +89,18 @@ export function createEntryShakingPlugin(userOptions: PluginOptions): Plugin[] {
         }
       },
 
-      load(id) {
+      async load(id) {
+        await context.init();
         return context.loadFile(id);
       },
 
       async transform(code, id) {
+        await context.init();
         return await context.transformFile(code, id);
       },
 
       async handleHotUpdate({ file, modules, server, timestamp }) {
+        await context.init();
         const isEntryUpdate = await context.checkUpdate(file);
 
         if (!isEntryUpdate) return;

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -1,0 +1,126 @@
+import type { ResolveFn, ViteDevServer } from 'vite';
+import { normalizePath } from 'vite';
+import EntryAnalyzer from './analyze-entry';
+import type { Context } from './context';
+import type { EntryPath, ExtendedTargets } from './types';
+import { parseId } from './urls';
+import Utils from './utils';
+
+/** Plugin's module resolution utilities. */
+export class Resolver {
+  /** Target ids exactly as configured before importer-specific resolution. */
+  private targetSpecifiers = new Set<EntryPath>();
+
+  constructor(
+    private context: Context,
+    private resolveFn: ResolveFn,
+  ) {}
+
+  /**
+   * Uses Vite's final plugin container for module resolution when available.
+   * @param server Vite's development server.
+   */
+  public usePluginContainer(server: Partial<ViteDevServer>) {
+    const { pluginContainer } = server;
+    if (!pluginContainer) return;
+
+    const fallbackResolver = this.resolveFn;
+    this.resolveFn = async (id, importer, aliasOnly, ssr) => {
+      if (aliasOnly) return await fallbackResolver(id, importer, aliasOnly, ssr);
+
+      const resolved = await pluginContainer.resolveId(id, importer, { ssr });
+      if (resolved) return typeof resolved === 'string' ? resolved : resolved.id;
+
+      return await fallbackResolver(id, importer, aliasOnly, ssr);
+    };
+  }
+
+  /**
+   * Resolves and normalizes a module id through the active Vite resolver.
+   * @param id Imported id/specifier.
+   * @param importer Importer id.
+   * @param aliasOnly Whether only aliases should be resolved.
+   * @param ssr Whether the resolution is for SSR.
+   */
+  public async resolve(id: string, importer?: string, aliasOnly?: boolean, ssr?: boolean) {
+    const resolved = await this.resolveFn(id, importer, aliasOnly, ssr);
+    return resolved ? this.normalizeId(resolved) : undefined;
+  }
+
+  /**
+   * Normalizes a module id before using it as a target/entry cache key.
+   * @param id Module id.
+   */
+  public normalizeId(id: string) {
+    return normalizePath(parseId(id).url);
+  }
+
+  /** Resolves and registers targets from the plugin options. */
+  public async registerTargets() {
+    const paths = await Utils.getAllTargetPaths(this.context.options.targets);
+    const targets: ExtendedTargets = new Map();
+    this.targetSpecifiers.clear();
+
+    await Utils.parallelize(paths, async (path) => {
+      this.targetSpecifiers.add(path);
+      const resolvedPath = (await this.resolve(path)) ?? this.normalizeId(path);
+      this.context.logger.debug(`Registered target "${path}" as "${resolvedPath}"`);
+      targets.set(resolvedPath, 0);
+    });
+
+    this.context.targets = targets;
+  }
+
+  /**
+   * Resolves an import with its real importer and ensures configured targets are
+   * analyzed under the final resolved identity.
+   * @param importPath Import specifier from the importer source.
+   * @param importer Importer id.
+   */
+  public async resolveEntryImport(importPath: string, importer: string) {
+    const resolvedPath = await this.resolve(importPath, importer);
+    if (!resolvedPath) return;
+
+    if (this.context.entries.has(resolvedPath)) return resolvedPath;
+    if (!(await this.isResolvedTargetImport(importPath, importer, resolvedPath))) return;
+
+    this.context.logger.info(
+      `Adding importer-resolved target "${importPath}" as "${resolvedPath}"`,
+    );
+    this.context.targets.set(resolvedPath, 0);
+    await EntryAnalyzer.analyzeEntry(this.context, resolvedPath, 0);
+    this.context.hmr.watchEntryFile(resolvedPath);
+
+    return this.context.entries.has(resolvedPath) ? resolvedPath : undefined;
+  }
+
+  private async isResolvedTargetImport(
+    importPath: string,
+    importer: string,
+    resolvedPath: string,
+  ) {
+    if (this.isTargetSpecifier(importPath)) return true;
+
+    for (const targetSpecifier of this.targetSpecifiers) {
+      const resolvedTarget = await this.resolve(targetSpecifier, importer);
+      if (resolvedTarget === resolvedPath) return true;
+    }
+
+    return false;
+  }
+
+  private isTargetSpecifier(importPath: string) {
+    const normalizedImport = this.normalizeId(importPath);
+
+    for (const targetSpecifier of this.targetSpecifiers) {
+      if (
+        targetSpecifier === importPath ||
+        this.normalizeId(targetSpecifier) === normalizedImport
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -89,7 +89,6 @@ export class Resolver {
     );
     this.context.targets.set(resolvedPath, 0);
     await EntryAnalyzer.analyzeEntry(this.context, resolvedPath, 0);
-    this.context.hmr.watchEntryFile(resolvedPath);
 
     return this.context.entries.has(resolvedPath) ? resolvedPath : undefined;
   }

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -112,7 +112,7 @@ export async function transformImports(
 
   // Analyze the imported entities of the file.
   for (const { n: path, ss: startPosition, se: endPosition } of imports) {
-    const resolvedImport = path && (await ctx.resolve(path, id));
+    const resolvedImport = path && (await ctx.resolveEntryImport(path, id));
     const entry = resolvedImport && ctx.entries.get(resolvedImport);
     // If the active import is one of the targets, let's analyze it.
     if (entry) {
@@ -157,7 +157,7 @@ export async function getEntryImports(
     return await imports.reduce(
       async (out, importParams) => {
         const { n: importPath } = importParams;
-        const resolvedPath = importPath && (await ctx.resolve(importPath, id));
+        const resolvedPath = importPath && (await ctx.resolveEntryImport(importPath, id));
         if (resolvedPath && ctx.entries.has(resolvedPath)) (await out).push(resolvedPath);
         return out;
       },

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -60,6 +60,7 @@ export async function transformImportsIfNeeded(
   const entriesMatched = importedEntries.length;
   const { transformImports: transform } = methods;
   if (!entriesMatched) {
+    ctx.unregisterEntryImporter(id);
     const ignoredMessage = `Did not transform "${id}" because it does not import any registered target`;
     ctx.logger.debug(ignoredMessage, undefined);
     return;
@@ -74,6 +75,7 @@ export async function transformImportsIfNeeded(
     `Transforming file "${id}"`,
     async () => await transform(ctx, id, code, imports, exports),
   );
+  ctx.registerEntryImporter(id, importedEntries);
 
   ctx.eventBus?.emit('registerTransform', {
     id,

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -112,7 +112,7 @@ export async function transformImports(
 
   // Analyze the imported entities of the file.
   for (const { n: path, ss: startPosition, se: endPosition } of imports) {
-    const resolvedImport = path && (await ctx.resolver(path, id));
+    const resolvedImport = path && (await ctx.resolve(path, id));
     const entry = resolvedImport && ctx.entries.get(resolvedImport);
     // If the active import is one of the targets, let's analyze it.
     if (entry) {
@@ -157,7 +157,7 @@ export async function getEntryImports(
     return await imports.reduce(
       async (out, importParams) => {
         const { n: importPath } = importParams;
-        const resolvedPath = importPath && (await ctx.resolver(importPath, id));
+        const resolvedPath = importPath && (await ctx.resolve(importPath, id));
         if (resolvedPath && ctx.entries.has(resolvedPath)) (await out).push(resolvedPath);
         return out;
       },

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -60,7 +60,7 @@ export async function transformImportsIfNeeded(
   const entriesMatched = importedEntries.length;
   const { transformImports: transform } = methods;
   if (!entriesMatched) {
-    ctx.unregisterEntryImporter(id);
+    ctx.hmr.unregisterEntryImporter(id);
     const ignoredMessage = `Did not transform "${id}" because it does not import any registered target`;
     ctx.logger.debug(ignoredMessage, undefined);
     return;
@@ -75,7 +75,7 @@ export async function transformImportsIfNeeded(
     `Transforming file "${id}"`,
     async () => await transform(ctx, id, code, imports, exports),
   );
-  ctx.registerEntryImporter(id, importedEntries);
+  ctx.hmr.registerEntryImporter(id, importedEntries);
 
   ctx.eventBus?.emit('registerTransform', {
     id,
@@ -112,7 +112,7 @@ export async function transformImports(
 
   // Analyze the imported entities of the file.
   for (const { n: path, ss: startPosition, se: endPosition } of imports) {
-    const resolvedImport = path && (await ctx.resolveEntryImport(path, id));
+    const resolvedImport = path && (await ctx.resolver.resolveEntryImport(path, id));
     const entry = resolvedImport && ctx.entries.get(resolvedImport);
     // If the active import is one of the targets, let's analyze it.
     if (entry) {
@@ -157,7 +157,7 @@ export async function getEntryImports(
     return await imports.reduce(
       async (out, importParams) => {
         const { n: importPath } = importParams;
-        const resolvedPath = importPath && (await ctx.resolveEntryImport(importPath, id));
+        const resolvedPath = importPath && (await ctx.resolver.resolveEntryImport(importPath, id));
         if (resolvedPath && ctx.entries.has(resolvedPath)) (await out).push(resolvedPath);
         return out;
       },

--- a/packages/core/tests/__mocks__/remap/consumer-mode-watcher.ts
+++ b/packages/core/tests/__mocks__/remap/consumer-mode-watcher.ts
@@ -1,3 +1,3 @@
-import { ModeWatcher, ObjectValue, String } from '@cms/core/admin';
+import { ModeWatcher, ObjectValue, String } from 'mode-watcher';
 
 export const ConsumerValue = `${ModeWatcher}:${String}:${ObjectValue}`;

--- a/packages/core/tests/__mocks__/remap/consumer-test.ts
+++ b/packages/core/tests/__mocks__/remap/consumer-test.ts
@@ -1,0 +1,3 @@
+import { ObjectValue, String } from '@cms/test/admin';
+
+export const ConsumerValue = `${String}:${ObjectValue}`;

--- a/packages/core/tests/__mocks__/remap/consumer-test.ts
+++ b/packages/core/tests/__mocks__/remap/consumer-test.ts
@@ -1,3 +1,0 @@
-import { ObjectValue, String } from '@cms/test/admin';
-
-export const ConsumerValue = `${String}:${ObjectValue}`;

--- a/packages/core/tests/__mocks__/remap/consumer.ts
+++ b/packages/core/tests/__mocks__/remap/consumer.ts
@@ -1,0 +1,3 @@
+import { ObjectValue, String } from '@cms/core/admin';
+
+export const ConsumerValue = `${String}:${ObjectValue}`;

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/ModeWatcher.svelte
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/ModeWatcher.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  export let defaultMode = 'dark';
+</script>
+
+<div>{defaultMode}</div>

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/index.ts
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/index.ts
@@ -1,0 +1,3 @@
+export { ObjectValue } from './object';
+
+export const NumberValue = 1;

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/index.ts
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/index.ts
@@ -1,3 +1,1 @@
-export { ObjectValue } from './object';
-
-export const NumberValue = 1;
+export * from './mode-watcher';

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/mode-watcher.ts
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/mode-watcher.ts
@@ -1,0 +1,4 @@
+export { ObjectValue } from './object';
+export { default as ModeWatcher } from './ModeWatcher.svelte';
+
+export const String = 'core-string';

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/object.ts
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/core/admin/dist/lib/object.ts
@@ -1,0 +1,1 @@
+export const ObjectValue = 'core-object';

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/core/package.json
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/core/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@cms/core",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./admin": "./admin/dist/lib/index.ts"
+  }
+}

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/ModeWatcher.svelte
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/ModeWatcher.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  export let defaultMode = 'light';
+</script>
+
+<div>{defaultMode}</div>

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/index.ts
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/index.ts
@@ -1,3 +1,1 @@
-export { ObjectValue } from './object';
-
-export const String = 'test-string';
+export * from './mode-watcher';

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/index.ts
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/index.ts
@@ -1,0 +1,3 @@
+export { ObjectValue } from './object';
+
+export const String = 'test-string';

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/mode-watcher.ts
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/mode-watcher.ts
@@ -1,0 +1,4 @@
+export { ObjectValue } from './object';
+export { default as ModeWatcher } from './ModeWatcher.svelte';
+
+export const String = 'test-string';

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/object.ts
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/test/admin/dist/lib/object.ts
@@ -1,0 +1,1 @@
+export const ObjectValue = 'test-object';

--- a/packages/core/tests/__mocks__/remap/node_modules/@cms/test/package.json
+++ b/packages/core/tests/__mocks__/remap/node_modules/@cms/test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@cms/test",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./admin": "./admin/dist/lib/index.ts"
+  }
+}

--- a/packages/core/tests/analyze-import.test.ts
+++ b/packages/core/tests/analyze-import.test.ts
@@ -386,7 +386,7 @@ describe('findNamedImport', () => {
     const ctx = await createTestContext({ targets: [] });
     const entry = { exports: new Map([[name, { path: 'path/to/export' }]]) } as EntryData;
     const map = new Map() as TargetImports;
-    vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+    vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
 
     const output = await ImportAnalyzer.findNamedImport(ctx, entry, entryPath, map, name, alias);
 
@@ -402,7 +402,7 @@ describe('findNamedImport', () => {
     const ctx = await createTestContext({ targets: [] });
     const entry = { exports: new Map([[name, { path: 'path/to/export' }]]) } as EntryData;
     const map = new Map([[resolvedPath, [{ name: 'first' }]]]) as TargetImports;
-    vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+    vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
 
     const output = await ImportAnalyzer.findNamedImport(ctx, entry, entryPath, map, name, alias);
 
@@ -450,7 +450,7 @@ describe('findNamedWildcard', () => {
     const entry = { wildcardExports: { named: new Map([[name, {} as any]]) } } as EntryData;
     const map = new Map() as TargetImports;
 
-    vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+    vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
     const output = await ImportAnalyzer.findNamedWildcard(ctx, entry, entryPath, map, name);
 
     expect(output).toStrictEqual(undefined);
@@ -465,7 +465,7 @@ describe('findNamedWildcard', () => {
     ctx.entries = new Map([[resolvedPath, {} as EntryData]]);
     const entry = { wildcardExports: { named: new Map([[name, {} as any]]) } } as EntryData;
     const map = new Map() as TargetImports;
-    vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+    vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
 
     const output = await ImportAnalyzer.findNamedWildcard(ctx, entry, entryPath, map, name);
 
@@ -481,7 +481,7 @@ describe('findNamedWildcard', () => {
     ctx.entries = new Map([[resolvedPath, {} as EntryData]]);
     const entry = { wildcardExports: { named: new Map([[name, {} as any]]) } } as EntryData;
     const map = new Map([[resolvedPath, [{ name: 'first' }]]]) as TargetImports;
-    vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+    vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
 
     const output = await ImportAnalyzer.findNamedWildcard(ctx, entry, entryPath, map, name);
 
@@ -521,7 +521,7 @@ describe('findDirectWildcardExports', () => {
     ctx.entries = new Map([[resolvedPath, { exports: new Map([[name, {}]]) } as EntryData]]);
     const entry = { wildcardExports: { direct: ['path/to/import'] as string[] } } as EntryData;
     const map = new Map() as TargetImports;
-    vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+    vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
 
     const fn = ImportAnalyzer.findDirectWildcardExports;
     const output = await fn(ctx, entry, entryPath, map, name, alias);
@@ -540,7 +540,7 @@ describe('findDirectWildcardExports', () => {
     ctx.entries = new Map([[resolvedPath, { exports: new Map([[name, {}]]) } as EntryData]]);
     const entry = { wildcardExports: { direct: ['path/to/import'] as string[] } } as EntryData;
     const map = new Map() as TargetImports;
-    vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+    vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
 
     const fn = ImportAnalyzer.findDirectWildcardExports;
     const output = await fn(ctx, entry, entryPath, map, name, alias);
@@ -562,7 +562,7 @@ describe('findDirectWildcardExports', () => {
       ]);
       const entry = { wildcardExports: { direct: ['path/to/import'] as string[] } } as EntryData;
       const map = new Map() as TargetImports;
-      vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+      vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
       vi.spyOn(ImportAnalyzer, 'resolveImport').mockImplementationOnce(() => Promise.resolve(true));
 
       const fn = ImportAnalyzer.findDirectWildcardExports;
@@ -583,7 +583,7 @@ describe('findDirectWildcardExports', () => {
       ]);
       const entry = { wildcardExports: { direct: ['path/to/import'] as string[] } } as EntryData;
       const map = new Map() as TargetImports;
-      vi.spyOn(ctx, 'resolver').mockImplementationOnce(() => Promise.resolve(resolvedPath));
+      vi.spyOn(ctx.resolver, 'resolve').mockImplementationOnce(() => Promise.resolve(resolvedPath));
       vi.spyOn(ImportAnalyzer, 'resolveImport').mockImplementationOnce(() =>
         Promise.resolve(false),
       );
@@ -649,9 +649,46 @@ describe('resolveImportedEntities', () => {
   });
 });
 
-/** Let's rely on syntax-related integration tests for now, it seems exhausting testing this. */
-describe.todo('resolveImportedCircularEntities', () => {
-  // …
+describe('resolveImportedCircularEntities', () => {
+  it('should preserve the requested binding name when resolving an aliased re-export', async () => {
+    const entryPath = '/entry.ts';
+    const sourcePath = '/source.ts';
+    const ctx = await createTestContext({ targets: [] });
+    ctx.entries = new Map([
+      [
+        entryPath,
+        {
+          exports: new Map([
+            [
+              'entryName',
+              {
+                path: sourcePath,
+                importDefault: false,
+                originalName: 'sourceName',
+              },
+            ],
+          ]),
+        } as EntryData,
+      ],
+    ]);
+    vi.spyOn(ctx.resolver, 'resolve').mockResolvedValue(sourcePath);
+
+    const output = await ImportAnalyzer.resolveImportedCircularEntities(
+      ctx,
+      [
+        {
+          name: 'publicName',
+          originalName: 'entryName',
+          importDefault: false,
+        },
+      ],
+      entryPath,
+    );
+
+    expect(output).toStrictEqual([
+      `import { sourceName as publicName } from '${sourcePath}'`,
+    ]);
+  });
 });
 
 describe('formatImportReplacement', () => {

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1,0 +1,135 @@
+import type { ModuleGraph, ModuleNode } from 'vite';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import EntryAnalyzer from '../src/analyze-entry';
+import { addSourceQuerySuffix } from '../src/urls';
+import { createMockEntryData, createTestContext } from './utils';
+
+const createModule = (id: string, file = id.split('?')[0]) =>
+  ({
+    id,
+    file,
+    url: id,
+  }) as ModuleNode;
+
+describe('Context HMR utilities', () => {
+  const entryId = '/path/to/entry.ts';
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should re-analyze entry updates and report whether the changed file is an entry', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    ctx.entries = new Map([[entryId, createMockEntryData()]]);
+    vi.spyOn(EntryAnalyzer, 'doAnalyzeEntry').mockResolvedValue([0, 0]);
+
+    await expect(ctx.checkUpdate(addSourceQuerySuffix(entryId))).resolves.toStrictEqual(true);
+    expect(EntryAnalyzer.doAnalyzeEntry).toHaveBeenCalledWith(ctx, entryId, 0);
+
+    await expect(ctx.checkUpdate('/path/to/other.ts')).resolves.toStrictEqual(false);
+    expect(EntryAnalyzer.doAnalyzeEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return normal and source served ids for entry updates only', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    ctx.entries = new Map([[entryId, createMockEntryData()]]);
+
+    expect(ctx.getHotUpdateModuleIds(entryId)).toStrictEqual([
+      entryId,
+      addSourceQuerySuffix(entryId),
+    ]);
+    expect(ctx.getHotUpdateModuleIds('/path/to/other.ts')).toStrictEqual([]);
+  });
+
+  it('should collect entry modules and plugin source variants from Vite module graph', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    const sourceId = addSourceQuerySuffix(entryId);
+    const normalModule = createModule(entryId);
+    const sourceModule = createModule(sourceId, entryId);
+    const unrelatedQueryModule = createModule(`${entryId}?raw`, entryId);
+    const unrelatedModule = createModule('/path/to/other.ts');
+    const modulesById = new Map([
+      [entryId, normalModule],
+      [sourceId, sourceModule],
+      [unrelatedQueryModule.id, unrelatedQueryModule],
+    ]);
+    const moduleGraph = {
+      getModuleById: vi.fn((id: string) => modulesById.get(id)),
+      getModulesByFile: vi.fn(() => new Set([sourceModule, unrelatedQueryModule])),
+    } as Pick<ModuleGraph, 'getModuleById' | 'getModulesByFile'>;
+
+    ctx.entries = new Map([[entryId, createMockEntryData()]]);
+
+    const modules = ctx.getHotUpdateModules(entryId, [normalModule, unrelatedModule], moduleGraph);
+
+    expect(new Set(modules)).toStrictEqual(new Set([normalModule, sourceModule]));
+    expect(moduleGraph.getModulesByFile).toHaveBeenCalledWith(entryId);
+    expect(moduleGraph.getModuleById).toHaveBeenCalledWith(entryId);
+    expect(moduleGraph.getModuleById).toHaveBeenCalledWith(sourceId);
+  });
+
+  it('should collect transformed importers that depended on the changed entry analysis', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    const importerId = '/path/to/consumer.ts';
+    const normalModule = createModule(entryId);
+    const importerModule = createModule(importerId);
+    const modulesById = new Map([
+      [entryId, normalModule],
+      [importerId, importerModule],
+    ]);
+    const moduleGraph = {
+      getModuleById: vi.fn((id: string) => modulesById.get(id)),
+      getModulesByFile: vi.fn(() => new Set<ModuleNode>()),
+    } as Pick<ModuleGraph, 'getModuleById' | 'getModulesByFile'>;
+
+    ctx.entries = new Map([[entryId, createMockEntryData()]]);
+    ctx.registerEntryImporter(importerId, [entryId]);
+
+    const modules = ctx.getHotUpdateModules(entryId, [normalModule], moduleGraph);
+
+    expect(new Set(modules)).toStrictEqual(new Set([normalModule, importerModule]));
+    expect(moduleGraph.getModuleById).toHaveBeenCalledWith(importerId);
+  });
+
+  it('should remove stale transformed importer references before registering new ones', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    const importerId = '/path/to/consumer.ts';
+    const otherEntryId = '/path/to/other-entry.ts';
+    ctx.entries = new Map([
+      [entryId, createMockEntryData()],
+      [otherEntryId, createMockEntryData()],
+    ]);
+
+    ctx.registerEntryImporter(importerId, [entryId]);
+    ctx.registerEntryImporter(importerId, [otherEntryId]);
+
+    expect(ctx.entryImporters.get(entryId)).toBeUndefined();
+    expect(ctx.entryImporters.get(otherEntryId)).toStrictEqual(new Set([importerId]));
+  });
+
+  it('should add entry exceptions to Vite watcher ignored options', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    const existingIgnore = /existing/;
+    ctx.entries = new Map([[entryId, createMockEntryData()]]);
+    ctx.config.server = {
+      watch: {
+        ignored: existingIgnore,
+      },
+    } as any;
+
+    ctx.includeEntriesInWatcherOptions();
+
+    expect(ctx.config.server.watch?.ignored).toStrictEqual([`!${entryId}`, existingIgnore]);
+  });
+
+  it('should add registered entries to Vite watcher', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    const add = vi.fn();
+    ctx.entries = new Map([[entryId, createMockEntryData()]]);
+
+    ctx.watchEntryFiles({ add });
+
+    expect(add).toHaveBeenCalledWith([entryId]);
+  });
+});

--- a/packages/core/tests/hmr.test.ts
+++ b/packages/core/tests/hmr.test.ts
@@ -12,7 +12,7 @@ const createModule = (id: string, file = id.split('?')[0]) =>
     url: id,
   }) as ModuleNode;
 
-describe('Context HMR utilities', () => {
+describe('HMR', () => {
   const entryId = '/path/to/entry.ts';
 
   beforeEach(() => {
@@ -24,10 +24,10 @@ describe('Context HMR utilities', () => {
     ctx.entries = new Map([[entryId, createMockEntryData()]]);
     vi.spyOn(EntryAnalyzer, 'doAnalyzeEntry').mockResolvedValue([0, 0]);
 
-    await expect(ctx.checkUpdate(addSourceQuerySuffix(entryId))).resolves.toStrictEqual(true);
+    await expect(ctx.hmr.checkUpdate(addSourceQuerySuffix(entryId))).resolves.toStrictEqual(true);
     expect(EntryAnalyzer.doAnalyzeEntry).toHaveBeenCalledWith(ctx, entryId, 0);
 
-    await expect(ctx.checkUpdate('/path/to/other.ts')).resolves.toStrictEqual(false);
+    await expect(ctx.hmr.checkUpdate('/path/to/other.ts')).resolves.toStrictEqual(false);
     expect(EntryAnalyzer.doAnalyzeEntry).toHaveBeenCalledTimes(1);
   });
 
@@ -35,11 +35,11 @@ describe('Context HMR utilities', () => {
     const ctx = await createTestContext({ targets: [] });
     ctx.entries = new Map([[entryId, createMockEntryData()]]);
 
-    expect(ctx.getHotUpdateModuleIds(entryId)).toStrictEqual([
+    expect(ctx.hmr.getHotUpdateModuleIds(entryId)).toStrictEqual([
       entryId,
       addSourceQuerySuffix(entryId),
     ]);
-    expect(ctx.getHotUpdateModuleIds('/path/to/other.ts')).toStrictEqual([]);
+    expect(ctx.hmr.getHotUpdateModuleIds('/path/to/other.ts')).toStrictEqual([]);
   });
 
   it('should collect entry modules and plugin source variants from Vite module graph', async () => {
@@ -61,7 +61,11 @@ describe('Context HMR utilities', () => {
 
     ctx.entries = new Map([[entryId, createMockEntryData()]]);
 
-    const modules = ctx.getHotUpdateModules(entryId, [normalModule, unrelatedModule], moduleGraph);
+    const modules = ctx.hmr.getHotUpdateModules(
+      entryId,
+      [normalModule, unrelatedModule],
+      moduleGraph,
+    );
 
     expect(new Set(modules)).toStrictEqual(new Set([normalModule, sourceModule]));
     expect(moduleGraph.getModulesByFile).toHaveBeenCalledWith(entryId);
@@ -84,9 +88,9 @@ describe('Context HMR utilities', () => {
     } as Pick<ModuleGraph, 'getModuleById' | 'getModulesByFile'>;
 
     ctx.entries = new Map([[entryId, createMockEntryData()]]);
-    ctx.registerEntryImporter(importerId, [entryId]);
+    ctx.hmr.registerEntryImporter(importerId, [entryId]);
 
-    const modules = ctx.getHotUpdateModules(entryId, [normalModule], moduleGraph);
+    const modules = ctx.hmr.getHotUpdateModules(entryId, [normalModule], moduleGraph);
 
     expect(new Set(modules)).toStrictEqual(new Set([normalModule, importerModule]));
     expect(moduleGraph.getModuleById).toHaveBeenCalledWith(importerId);
@@ -101,24 +105,26 @@ describe('Context HMR utilities', () => {
       [otherEntryId, createMockEntryData()],
     ]);
 
-    ctx.registerEntryImporter(importerId, [entryId]);
-    ctx.registerEntryImporter(importerId, [otherEntryId]);
+    ctx.hmr.registerEntryImporter(importerId, [entryId]);
+    ctx.hmr.registerEntryImporter(importerId, [otherEntryId]);
 
-    expect(ctx.entryImporters.get(entryId)).toBeUndefined();
-    expect(ctx.entryImporters.get(otherEntryId)).toStrictEqual(new Set([importerId]));
+    expect(ctx.hmr.entryImporters.get(entryId)).toBeUndefined();
+    expect(ctx.hmr.entryImporters.get(otherEntryId)).toStrictEqual(new Set([importerId]));
   });
 
   it('should add entry exceptions to Vite watcher ignored options', async () => {
     const ctx = await createTestContext({ targets: [] });
     const existingIgnore = /existing/;
     ctx.entries = new Map([[entryId, createMockEntryData()]]);
-    ctx.config.server = {
-      watch: {
-        ignored: existingIgnore,
+    Object.assign(ctx.config, {
+      server: {
+        watch: {
+          ignored: existingIgnore,
+        },
       },
-    } as any;
+    });
 
-    ctx.includeEntriesInWatcherOptions();
+    ctx.hmr.includeEntriesInWatcherOptions();
 
     expect(ctx.config.server.watch?.ignored).toStrictEqual([`!${entryId}`, existingIgnore]);
   });
@@ -128,7 +134,7 @@ describe('Context HMR utilities', () => {
     const add = vi.fn();
     ctx.entries = new Map([[entryId, createMockEntryData()]]);
 
-    ctx.watchEntryFiles({ add });
+    ctx.hmr.watchEntryFiles({ add });
 
     expect(add).toHaveBeenCalledWith([entryId]);
   });

--- a/packages/core/tests/hmr.test.ts
+++ b/packages/core/tests/hmr.test.ts
@@ -134,8 +134,39 @@ describe('HMR', () => {
     const add = vi.fn();
     ctx.entries = new Map([[entryId, createMockEntryData()]]);
 
-    ctx.hmr.watchEntryFiles({ add });
+    const watcher = { add, options: { ignored: [] } };
+    ctx.hmr.watchEntryFiles(watcher);
 
     expect(add).toHaveBeenCalledWith([entryId]);
+    expect(watcher.options.ignored).toStrictEqual([`!${entryId}`]);
+  });
+
+  it('should keep late entries out of ignored paths before adding them to Vite watcher', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    const add = vi.fn();
+    const lateEntryId = '/path/to/node_modules/late-entry.ts';
+    const watcher = {
+      add,
+      options: { ignored: ['**/node_modules/**'] },
+    };
+
+    ctx.hmr.watchEntryFiles(watcher);
+    ctx.hmr.watchEntryFile(lateEntryId);
+
+    expect(watcher.options.ignored).toStrictEqual([`!${lateEntryId}`, '**/node_modules/**']);
+    expect(add).toHaveBeenLastCalledWith(lateEntryId);
+  });
+
+  it('should watch entries registered before the Vite watcher is available', async () => {
+    const ctx = await createTestContext({ targets: [] });
+    const add = vi.fn();
+    const earlyEntryId = '/path/to/node_modules/early-entry.ts';
+    const watcher = { add, options: { ignored: ['**/node_modules/**'] } };
+
+    ctx.hmr.watchEntryFile(earlyEntryId);
+    ctx.hmr.watchEntryFiles(watcher);
+
+    expect(add).toHaveBeenCalledWith([earlyEntryId]);
+    expect(watcher.options.ignored).toContain(`!${earlyEntryId}`);
   });
 });

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -30,6 +30,7 @@ const createServer = (modules: ModuleNode[]) => {
     moduleGraph,
     watcher: {
       add,
+      options: { ignored: [] },
     },
     ws: {
       send,

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -1,0 +1,146 @@
+import type { ModuleGraph, ModuleNode, ViteDevServer } from 'vite';
+import { resolveConfig } from 'vite';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { createEntryShakingPlugin } from '../src';
+import { addSourceQuerySuffix } from '../src/urls';
+import { resolveUnitEntry, VITE_CONFIG } from './utils';
+
+const createModule = (id: string, file = id.split('?')[0]) =>
+  ({
+    id,
+    file,
+    url: id,
+  }) as ModuleNode;
+
+const createServer = (modules: ModuleNode[]) => {
+  const modulesById = new Map(modules.map((module) => [module.id, module]));
+  const invalidateModule = vi.fn();
+  const send = vi.fn();
+  const add = vi.fn();
+  const moduleGraph = {
+    getModuleById: vi.fn((id: string) => modulesById.get(id)),
+    getModulesByFile: vi.fn(
+      (file: string) => new Set(modules.filter((module) => module.file === file)),
+    ),
+    invalidateModule,
+  } as unknown as ModuleGraph;
+
+  const server = {
+    moduleGraph,
+    watcher: {
+      add,
+    },
+    ws: {
+      send,
+    },
+  } as unknown as ViteDevServer;
+
+  return { add, invalidateModule, send, server };
+};
+
+const getEntryShakingPlugin = async (targets: string[]) => {
+  const plugins = createEntryShakingPlugin({ targets });
+  const config = await resolveConfig(VITE_CONFIG, 'serve');
+  const preConfigResolved = plugins[0].configResolved;
+  const mainConfigResolved = plugins[1].configResolved;
+
+  if (typeof preConfigResolved !== 'function' || typeof mainConfigResolved !== 'function') {
+    throw new Error('Expected test plugins to expose configResolved hooks');
+  }
+
+  await preConfigResolved(config);
+  await mainConfigResolved(config);
+
+  return plugins[1];
+};
+
+describe('createEntryShakingPlugin handleHotUpdate', () => {
+  let entryId: string;
+
+  beforeAll(async () => {
+    entryId = await resolveUnitEntry('entry-a');
+  });
+
+  it('should re-analyze, invalidate entry variants and reload when an entry file changes', async () => {
+    const sourceId = addSourceQuerySuffix(entryId);
+    const importerId = '/path/to/consumer.ts';
+    const normalModule = createModule(entryId);
+    const sourceModule = createModule(sourceId, entryId);
+    const importerModule = createModule(importerId);
+    const { invalidateModule, send, server } = createServer([
+      normalModule,
+      sourceModule,
+      importerModule,
+    ]);
+    const plugin = await getEntryShakingPlugin([entryId]);
+    const timestamp = 123;
+
+    await plugin.transform?.("import { A_MODULE_A } from '@mocks/entry-a';", importerId);
+
+    const result = await plugin.handleHotUpdate?.({
+      file: entryId,
+      modules: [normalModule],
+      server,
+      timestamp,
+      read: vi.fn(),
+    });
+
+    expect(result).toStrictEqual([]);
+    expect(invalidateModule).toHaveBeenCalledTimes(3);
+    expect(invalidateModule).toHaveBeenNthCalledWith(
+      1,
+      normalModule,
+      expect.any(Set),
+      timestamp,
+      true,
+    );
+    expect(invalidateModule).toHaveBeenNthCalledWith(
+      2,
+      sourceModule,
+      expect.any(Set),
+      timestamp,
+      true,
+    );
+    expect(invalidateModule).toHaveBeenNthCalledWith(
+      3,
+      importerModule,
+      expect.any(Set),
+      timestamp,
+      true,
+    );
+    expect(send).toHaveBeenCalledWith({ type: 'full-reload' });
+  });
+
+  it('should add analyzed entries to Vite watcher on server configuration', async () => {
+    const { add, server } = createServer([]);
+    const plugin = await getEntryShakingPlugin([entryId]);
+    const configureServer = plugin.configureServer;
+
+    if (typeof configureServer !== 'function') {
+      throw new Error('Expected test plugin to expose configureServer hook');
+    }
+
+    await configureServer(server);
+
+    expect(add).toHaveBeenCalledWith([entryId]);
+  });
+
+  it('should preserve Vite default HMR handling for non-entry files', async () => {
+    const otherModule = createModule('/path/to/other.ts');
+    const { invalidateModule, send, server } = createServer([otherModule]);
+    const plugin = await getEntryShakingPlugin([entryId]);
+
+    const result = await plugin.handleHotUpdate?.({
+      file: otherModule.id!,
+      modules: [otherModule],
+      server,
+      timestamp: 456,
+      read: vi.fn(),
+    });
+
+    expect(result).toBeUndefined();
+    expect(invalidateModule).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/remap-resolution.test.ts
+++ b/packages/core/tests/remap-resolution.test.ts
@@ -1,0 +1,113 @@
+import { resolve } from 'path';
+import type { Plugin, ViteDevServer } from 'vite';
+import { createServer, normalizePath } from 'vite';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createEntryShakingPlugin } from '../src';
+
+const fixtureRoot = normalizePath(resolve(__dirname, '__mocks__/remap'));
+const consumerPath = normalizePath(resolve(fixtureRoot, 'consumer.ts'));
+const testConsumerPath = normalizePath(resolve(fixtureRoot, 'consumer-test.ts'));
+const testEntryPath = normalizePath(
+  resolve(fixtureRoot, 'node_modules/@cms/test/admin/dist/lib/index.ts'),
+);
+
+type RemapMode = 'package-entry' | 'concrete-file';
+
+function remapCmsCoreAdmin(mode: RemapMode): Plugin {
+  return {
+    name: `test-remap-cms-core-admin-${mode}`,
+    enforce: 'pre',
+    async resolveId(id, importer) {
+      if (id !== '@cms/core/admin') return;
+
+      if (mode === 'concrete-file') return testEntryPath;
+
+      const resolved = await this.resolve('@cms/test/admin', importer, { skipSelf: true });
+      return resolved ?? null;
+    },
+  };
+}
+
+async function createFixtureServer(target: string, remapMode?: RemapMode) {
+  return await createServer({
+    appType: 'custom',
+    configFile: false,
+    logLevel: 'silent',
+    root: fixtureRoot,
+    optimizeDeps: {
+      include: [],
+      noDiscovery: true,
+    },
+    server: {
+      hmr: false,
+      middlewareMode: true,
+    },
+    plugins: [
+      ...(remapMode ? [remapCmsCoreAdmin(remapMode)] : []),
+      ...createEntryShakingPlugin({ targets: [target] }),
+    ],
+  });
+}
+
+function fsUrl(path: string) {
+  return `/@fs/${path}`;
+}
+
+function expectCodeUsesTestEntry(code: string) {
+  expect(code).toContain('/node_modules/@cms/test/admin/dist/lib/object.ts');
+  expect(code).toContain('/node_modules/@cms/test/admin/dist/lib/index.ts');
+  expect(code).not.toContain('/node_modules/@cms/core/admin/dist/lib/object.ts');
+  expect(code).not.toContain('/node_modules/@cms/core/admin/dist/lib/index.ts');
+  expect(code).not.toContain('@cms_test_admin');
+}
+
+function expectEntryProvidesString(entry: string) {
+  expect(entry).toMatch(/export const String = ["']test-string["'];/);
+}
+
+async function transformFile(server: ViteDevServer, path: string) {
+  const result = await server.transformRequest(fsUrl(path));
+  if (!result) throw new Error('Expected consumer transform result');
+  return result.code;
+}
+
+describe('resolveId remapped package entries', () => {
+  let server: ViteDevServer | undefined;
+
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+  });
+
+  it('preserves normal direct entry-shaking behavior without a remap', async () => {
+    server = await createFixtureServer('@cms/test/admin');
+
+    const code = await transformFile(server, testConsumerPath);
+    const entry = await transformFile(server, testEntryPath);
+
+    expectCodeUsesTestEntry(code);
+    expectEntryProvidesString(entry);
+  });
+
+  it('uses the final resolved package entry before building and using its export map', async () => {
+    server = await createFixtureServer('@cms/core/admin', 'package-entry');
+
+    const code = await transformFile(server, consumerPath);
+    const entry = await transformFile(server, testEntryPath);
+
+    expectCodeUsesTestEntry(code);
+    expectEntryProvidesString(entry);
+    expect(entry).not.toContain("export { ObjectValue } from './object';");
+  });
+
+  it('uses a remap to a concrete file as the target entry identity', async () => {
+    server = await createFixtureServer('@cms/core/admin', 'concrete-file');
+
+    const code = await transformFile(server, consumerPath);
+    const entry = await transformFile(server, testEntryPath);
+
+    expectCodeUsesTestEntry(code);
+    expectEntryProvidesString(entry);
+  });
+});

--- a/packages/core/tests/remap-resolution.test.ts
+++ b/packages/core/tests/remap-resolution.test.ts
@@ -23,12 +23,16 @@ const testModeWatcherPath = normalizePath(
 
 type RemapMode = 'package-entry' | 'concrete-file';
 
-function remapCmsCoreAdmin(mode: RemapMode, remapModeWatcher = false): Plugin {
+function remapCmsCoreAdmin(
+  mode: RemapMode,
+  remapModeWatcher = false,
+  remapTopLevel = false,
+): Plugin {
   return {
     name: `test-remap-cms-core-admin-${mode}`,
     enforce: 'pre',
     async resolveId(id, importer) {
-      if (!importer) return null;
+      if (!importer && !remapTopLevel) return null;
       if (id !== '@cms/core/admin' && (!remapModeWatcher || id !== 'mode-watcher')) return;
 
       if (mode === 'concrete-file') return testEntryPath;
@@ -43,6 +47,7 @@ async function createFixtureServer(
   target: string,
   remapMode?: RemapMode,
   remapModeWatcher = false,
+  remapTopLevel = false,
 ) {
   return await createServer({
     appType: 'custom',
@@ -58,7 +63,7 @@ async function createFixtureServer(
       middlewareMode: true,
     },
     plugins: [
-      ...(remapMode ? [remapCmsCoreAdmin(remapMode, remapModeWatcher)] : []),
+      ...(remapMode ? [remapCmsCoreAdmin(remapMode, remapModeWatcher, remapTopLevel)] : []),
       ...createEntryShakingPlugin({ maxWildcardDepth: 5, targets: [target] }),
     ],
   });
@@ -138,6 +143,22 @@ describe('resolveId remapped package entries', () => {
     expectCodeUsesPackage(code, 'test');
     expectEntryReexportsModeWatcher(entry, 'test');
     expectModeWatcherProvidesString(modeWatcher, 'test');
+  });
+
+  it('registers top-level targets through the final plugin container resolver', async () => {
+    server = await createFixtureServer('@cms/core/admin', 'concrete-file', false, true);
+
+    expect(server.watcher.options.ignored).toContain(`!${testEntryPath}`);
+    expect(server.watcher.options.ignored).not.toContain(`!${coreEntryPath}`);
+  });
+
+  it('watches importer-resolved entries and their late wildcard entries', async () => {
+    server = await createFixtureServer('@cms/core/admin', 'package-entry');
+
+    await transformFile(server, consumerPath);
+
+    expect(server.watcher.options.ignored).toContain(`!${testEntryPath}`);
+    expect(server.watcher.options.ignored).toContain(`!${testModeWatcherPath}`);
   });
 
   it('rewrites a non-target source import when another plugin resolves it to a target package entry', async () => {

--- a/packages/core/tests/remap-resolution.test.ts
+++ b/packages/core/tests/remap-resolution.test.ts
@@ -7,19 +7,29 @@ import { createEntryShakingPlugin } from '../src';
 
 const fixtureRoot = normalizePath(resolve(__dirname, '__mocks__/remap'));
 const consumerPath = normalizePath(resolve(fixtureRoot, 'consumer.ts'));
-const testConsumerPath = normalizePath(resolve(fixtureRoot, 'consumer-test.ts'));
+const modeWatcherConsumerPath = normalizePath(resolve(fixtureRoot, 'consumer-mode-watcher.ts'));
+const coreEntryPath = normalizePath(
+  resolve(fixtureRoot, 'node_modules/@cms/core/admin/dist/lib/index.ts'),
+);
+const coreModeWatcherPath = normalizePath(
+  resolve(fixtureRoot, 'node_modules/@cms/core/admin/dist/lib/mode-watcher.ts'),
+);
 const testEntryPath = normalizePath(
   resolve(fixtureRoot, 'node_modules/@cms/test/admin/dist/lib/index.ts'),
+);
+const testModeWatcherPath = normalizePath(
+  resolve(fixtureRoot, 'node_modules/@cms/test/admin/dist/lib/mode-watcher.ts'),
 );
 
 type RemapMode = 'package-entry' | 'concrete-file';
 
-function remapCmsCoreAdmin(mode: RemapMode): Plugin {
+function remapCmsCoreAdmin(mode: RemapMode, remapModeWatcher = false): Plugin {
   return {
     name: `test-remap-cms-core-admin-${mode}`,
     enforce: 'pre',
     async resolveId(id, importer) {
-      if (id !== '@cms/core/admin') return;
+      if (!importer) return null;
+      if (id !== '@cms/core/admin' && (!remapModeWatcher || id !== 'mode-watcher')) return;
 
       if (mode === 'concrete-file') return testEntryPath;
 
@@ -29,7 +39,11 @@ function remapCmsCoreAdmin(mode: RemapMode): Plugin {
   };
 }
 
-async function createFixtureServer(target: string, remapMode?: RemapMode) {
+async function createFixtureServer(
+  target: string,
+  remapMode?: RemapMode,
+  remapModeWatcher = false,
+) {
   return await createServer({
     appType: 'custom',
     configFile: false,
@@ -44,8 +58,8 @@ async function createFixtureServer(target: string, remapMode?: RemapMode) {
       middlewareMode: true,
     },
     plugins: [
-      ...(remapMode ? [remapCmsCoreAdmin(remapMode)] : []),
-      ...createEntryShakingPlugin({ targets: [target] }),
+      ...(remapMode ? [remapCmsCoreAdmin(remapMode, remapModeWatcher)] : []),
+      ...createEntryShakingPlugin({ maxWildcardDepth: 5, targets: [target] }),
     ],
   });
 }
@@ -54,16 +68,25 @@ function fsUrl(path: string) {
   return `/@fs/${path}`;
 }
 
-function expectCodeUsesTestEntry(code: string) {
-  expect(code).toContain('/node_modules/@cms/test/admin/dist/lib/object.ts');
-  expect(code).toContain('/node_modules/@cms/test/admin/dist/lib/index.ts');
-  expect(code).not.toContain('/node_modules/@cms/core/admin/dist/lib/object.ts');
-  expect(code).not.toContain('/node_modules/@cms/core/admin/dist/lib/index.ts');
+function expectCodeUsesPackage(code: string, packageName: 'core' | 'test') {
+  const otherPackageName = packageName === 'core' ? 'test' : 'core';
+  expect(code).toContain(`/node_modules/@cms/${packageName}/admin/dist/lib/ModeWatcher.svelte`);
+  expect(code).toContain(`/node_modules/@cms/${packageName}/admin/dist/lib/object.ts`);
+  expect(code).toContain(`/node_modules/@cms/${packageName}/admin/dist/lib/mode-watcher.ts`);
+  expect(code).not.toContain(`/node_modules/@cms/${otherPackageName}/admin/dist/lib/ModeWatcher.svelte`);
+  expect(code).not.toContain(`/node_modules/@cms/${otherPackageName}/admin/dist/lib/object.ts`);
+  expect(code).not.toContain(`/node_modules/@cms/${otherPackageName}/admin/dist/lib/index.ts`);
+  expect(code).not.toContain(`/node_modules/@cms/${otherPackageName}/admin/dist/lib/mode-watcher.ts`);
   expect(code).not.toContain('@cms_test_admin');
+  expect(code).toContain('default as ModeWatcher');
 }
 
-function expectEntryProvidesString(entry: string) {
-  expect(entry).toMatch(/export const String = ["']test-string["'];/);
+function expectEntryReexportsModeWatcher(entry: string, packageName: 'core' | 'test') {
+  expect(entry).toContain(`/node_modules/@cms/${packageName}/admin/dist/lib/mode-watcher.ts`);
+}
+
+function expectModeWatcherProvidesString(modeWatcher: string, packageName: 'core' | 'test') {
+  expect(modeWatcher).toMatch(new RegExp(`export const String = ["']${packageName}-string["'];`));
 }
 
 async function transformFile(server: ViteDevServer, path: string) {
@@ -81,13 +104,15 @@ describe('resolveId remapped package entries', () => {
   });
 
   it('preserves normal direct entry-shaking behavior without a remap', async () => {
-    server = await createFixtureServer('@cms/test/admin');
+    server = await createFixtureServer('@cms/core/admin');
 
-    const code = await transformFile(server, testConsumerPath);
-    const entry = await transformFile(server, testEntryPath);
+    const code = await transformFile(server, consumerPath);
+    const entry = await transformFile(server, coreEntryPath);
+    const modeWatcher = await transformFile(server, coreModeWatcherPath);
 
-    expectCodeUsesTestEntry(code);
-    expectEntryProvidesString(entry);
+    expectCodeUsesPackage(code, 'core');
+    expectEntryReexportsModeWatcher(entry, 'core');
+    expectModeWatcherProvidesString(modeWatcher, 'core');
   });
 
   it('uses the final resolved package entry before building and using its export map', async () => {
@@ -95,9 +120,11 @@ describe('resolveId remapped package entries', () => {
 
     const code = await transformFile(server, consumerPath);
     const entry = await transformFile(server, testEntryPath);
+    const modeWatcher = await transformFile(server, testModeWatcherPath);
 
-    expectCodeUsesTestEntry(code);
-    expectEntryProvidesString(entry);
+    expectCodeUsesPackage(code, 'test');
+    expectEntryReexportsModeWatcher(entry, 'test');
+    expectModeWatcherProvidesString(modeWatcher, 'test');
     expect(entry).not.toContain("export { ObjectValue } from './object';");
   });
 
@@ -106,8 +133,24 @@ describe('resolveId remapped package entries', () => {
 
     const code = await transformFile(server, consumerPath);
     const entry = await transformFile(server, testEntryPath);
+    const modeWatcher = await transformFile(server, testModeWatcherPath);
 
-    expectCodeUsesTestEntry(code);
-    expectEntryProvidesString(entry);
+    expectCodeUsesPackage(code, 'test');
+    expectEntryReexportsModeWatcher(entry, 'test');
+    expectModeWatcherProvidesString(modeWatcher, 'test');
+  });
+
+  it('rewrites a non-target source import when another plugin resolves it to a target package entry', async () => {
+    server = await createFixtureServer('@cms/core/admin', 'package-entry', true);
+
+    const code = await transformFile(server, modeWatcherConsumerPath);
+    const entry = await transformFile(server, testEntryPath);
+    const modeWatcher = await transformFile(server, testModeWatcherPath);
+
+    expectCodeUsesPackage(code, 'test');
+    expectEntryReexportsModeWatcher(entry, 'test');
+    expectModeWatcherProvidesString(modeWatcher, 'test');
+    expect(code).not.toContain('from "mode-watcher"');
+    expect(code).not.toContain("from 'mode-watcher'");
   });
 });

--- a/packages/core/tests/utils.ts
+++ b/packages/core/tests/utils.ts
@@ -262,7 +262,7 @@ export async function resolveUnitEntry(name: string) {
  * It creates it if it doesn't exist yet.
  */
 async function getResolver() {
-  return testResolver ??= await getTestResolver();
+  return (testResolver ??= await getTestResolver());
 }
 
 /**

--- a/packages/core/tests/utils.ts
+++ b/packages/core/tests/utils.ts
@@ -195,7 +195,7 @@ export async function createTestContext(options: PluginOptions) {
 
   const finalOptions = mergeOptions(options);
   const context = new Context(finalOptions, config);
-  await context['registerTargets']();
+  await context.resolver.registerTargets();
   return context;
 }
 

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -14,13 +14,7 @@
   "bugs": {
     "url": "https://github.com/Dschungelabenteuer/vite-plugin-entry-shaking/issues"
   },
-  "keywords": [
-    "vite",
-    "vite-plugin",
-    "entry",
-    "tree shaking",
-    "debugger"
-  ],
+  "keywords": ["vite", "vite-plugin", "entry", "tree shaking", "debugger"],
   "exports": {
     ".": {
       "require": {


### PR DESCRIPTION
## Summary
### HMR
- Watch analyzed entry files so Vite emits HMR updates when registered entries change
- Re-analyze changed entry files and invalidate served entry variants
- Track transformed importers that depended on entry analysis and invalidate them on entry HMR
- Add tests for entry HMR watcher registration, module invalidation, and importer invalidation
### resolveId
- Use Vite's final plugin-container resolution, normalize ids before caching entries, resolve import targets with real importer before deciding to rewrite

Sorry about the formatting changes, that came from running `pnpm format` so I guess something may have changed since they last ran.
A significant portion of this code was written by AI, however I've reviewed it and tested it in my complex project.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hot module replacement for registered, newly discovered, and remapped entry files.
  - Enhanced development-server handling for package entries, concrete files, wildcard re-exports, and aliased exports.
  - Ensured affected modules and importers refresh correctly, with full-reload fallback when necessary.

- **Tests**
  - Expanded coverage for HMR updates, file watching, remapped resolution, re-exports, and importer cleanup.

- **Chores**
  - Added a patch release note and applied configuration formatting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->