### PR TITLE
fix(core): preserve import alias when a symbol is left on the target entry

### DIFF
--- a/.changeset/preserve-alias-on-unresolved-import.md
+++ b/.changeset/preserve-alias-on-unresolved-import.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-entry-shaking": patch
+---
+
+Preserve the local alias of named imports that cannot be resolved to a concrete file (e.g. symbols reached through an `export *` re-export chain). Previously the alias was dropped when such an import fell back to being left on the target entry, so `import { X as Y }` was rewritten to `import { X }` while the module body still referenced `Y` — producing an undefined reference, or a duplicate-identifier crash when another `X` binding existed in the same module.

--- a/packages/core/src/analyze-import.ts
+++ b/packages/core/src/analyze-import.ts
@@ -81,7 +81,7 @@ async function getImportsMap(
     const found = await methods.resolveImport(ctx, entry, entryPath, map, name, alias);
     if (found) return;
 
-    map.set(entryPath, [...(map.get(entryPath) ?? []), { name, importDefault: false }]);
+    map.set(entryPath, [...(map.get(entryPath) ?? []), { name, importDefault: false, alias }]);
   });
 
   return map;

--- a/packages/core/tests/analyze-import.test.ts
+++ b/packages/core/tests/analyze-import.test.ts
@@ -297,6 +297,19 @@ describe('getImportsMap', async () => {
     expect(_(output)).toStrictEqual({
       importDefault: false,
       name: 'test',
+      alias: undefined,
+    });
+  });
+
+  it('should correctly feed the import map when [importing with alias] a named entity [directly defined in entry]', async () => {
+    const imports: string[] = ['test as T'];
+    const entryPath = (await resolver(resolve(__dirname, MOCKS_FOLDER_UNIT, 'entry-a')))!;
+    const output = await ImportAnalyzer.getImportsMap(ctx, entry, entryPath, imports);
+    expect(output.size).toStrictEqual(1);
+    expect(_(output)).toStrictEqual({
+      importDefault: false,
+      name: 'test',
+      alias: 'T',
     });
   });
 });


### PR DESCRIPTION
Fixes #68.

## Problem

When a consumer imports a symbol from a target entry using an alias (`import { X as Y }`), and that symbol can only be reached through an `export *` re-export chain the crawler doesn't resolve to a concrete file, the rewrite **drops the alias**. The import is re-emitted as `import { X }` from the entry, but the module body still references `Y`.

This causes either an **undefined reference** (`Y` is unbound), or — if the module also has another binding named `X` (e.g. a local `import X from './x'`) — a **duplicate-identifier crash**: `Identifier 'X' has already been declared`.

## Root cause

Every *resolved* branch (`findNamedImport`, `findDirectWildcardExports`, …) threads `alias` through, and `formatImportReplacement` already handles it. Only the unresolved fallback in `getImportsMap` forgot it:

```ts
const { name, alias } = Parsers.parseImportParams(importString);
const found = await methods.resolveImport(ctx, entry, entryPath, map, name, alias);
if (found) return;

// alias was dropped here:
map.set(entryPath, [...(map.get(entryPath) ?? []), { name, importDefault: false }]);
```

## Fix

One line — preserve `alias` on the fallback entry, exactly as the resolved branches do. `formatImportReplacement` then emits `X as Y` for the plain-named case.

## Tests

The `getImportsMap` suite already had an "import with alias" variant for every branch **except** this fallback — the gap that let the bug through. Added that missing variant (`'test as T'` → `{ name: 'test', alias: 'T', importDefault: false }`), and updated the existing fallback test to assert the now-preserved `alias` field.

Verified the new test fails without the fix (2 failing) and the full `analyze-import` suite passes with it (43 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)